### PR TITLE
Add support for TLSSkipVerify for https consul fabio check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,17 +106,18 @@ type File struct {
 }
 
 type Consul struct {
-	Addr          string
-	Scheme        string
-	Token         string
-	KVPath        string
-	TagPrefix     string
-	Register      bool
-	ServiceAddr   string
-	ServiceName   string
-	ServiceTags   []string
-	ServiceStatus []string
-	CheckInterval time.Duration
-	CheckTimeout  time.Duration
-	CheckScheme   string
+	Addr               string
+	Scheme             string
+	Token              string
+	KVPath             string
+	TagPrefix          string
+	Register           bool
+	ServiceAddr        string
+	ServiceName        string
+	ServiceTags        []string
+	ServiceStatus      []string
+	CheckInterval      time.Duration
+	CheckTimeout       time.Duration
+	CheckScheme        string
+	CheckTLSSkipVerify bool
 }

--- a/config/load.go
+++ b/config/load.go
@@ -162,6 +162,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.StringSliceVar(&cfg.Registry.Consul.ServiceStatus, "registry.consul.service.status", defaultConfig.Registry.Consul.ServiceStatus, "valid service status values")
 	f.DurationVar(&cfg.Registry.Consul.CheckInterval, "registry.consul.register.checkInterval", defaultConfig.Registry.Consul.CheckInterval, "service check interval")
 	f.DurationVar(&cfg.Registry.Consul.CheckTimeout, "registry.consul.register.checkTimeout", defaultConfig.Registry.Consul.CheckTimeout, "service check timeout")
+	f.BoolVar(&cfg.Registry.Consul.CheckTLSSkipVerify, "registry.consul.register.checkTLSSkipVerify", defaultConfig.Registry.Consul.CheckTLSSkipVerify, "service check TLS verifcation")
 	f.IntVar(&cfg.Runtime.GOGC, "runtime.gogc", defaultConfig.Runtime.GOGC, "sets runtime.GOGC")
 	f.IntVar(&cfg.Runtime.GOMAXPROCS, "runtime.gomaxprocs", defaultConfig.Runtime.GOMAXPROCS, "sets runtime.GOMAXPROCS")
 	f.StringVar(&uiListenerValue, "ui.addr", defaultValues.UIListenerValue, "Address the UI/API is listening on")

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -426,6 +426,13 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			args: []string{"-registry.consul.register.checkTLSSkipVerify=true"},
+			cfg: func(cfg *Config) *Config {
+				cfg.Registry.Consul.CheckTLSSkipVerify = true
+				return cfg
+			},
+		},
+		{
 			args: []string{"-registry.consul.register.tags", "a, b, c, "},
 			cfg: func(cfg *Config) *Config {
 				cfg.Registry.Consul.ServiceTags = []string{"a", "b", "c"}

--- a/fabio.properties
+++ b/fabio.properties
@@ -592,11 +592,12 @@
 #
 # registry.consul.register.checkTimeout = 3s
 
-# registry.consul.register.checkTLSSkipVerify configures whether or not to skip TLS verification for the health check.
+
+# registry.consul.register.checkTLSSkipVerify configures TLS verification for the health check.
 #
 # Fabio registers an http health check on http(s)://${ui.addr}/health
-# and this value tells consul whether or not to verify the TLS certificate
-# if it's being served over HTTPS
+# and this value tells consul to skip TLS certificate validation for 
+# https checks.
 #
 # The default is
 #

--- a/fabio.properties
+++ b/fabio.properties
@@ -592,6 +592,16 @@
 #
 # registry.consul.register.checkTimeout = 3s
 
+# registry.consul.register.checkTLSSkipVerify configures whether or not to skip TLS verification for the health check.
+#
+# Fabio registers an http health check on http(s)://${ui.addr}/health
+# and this value tells consul whether or not to verify the TLS certificate
+# if it's being served over HTTPS
+#
+# The default is
+#
+# registry.consul.register.checkTLSSkipVerify = false
+
 
 # metrics.target configures the backend the metrics values are
 # sent to.

--- a/registry/consul/register.go
+++ b/registry/consul/register.go
@@ -115,9 +115,10 @@ func serviceRegistration(cfg *config.Consul) (*api.AgentServiceRegistration, err
 		Port:    port,
 		Tags:    cfg.ServiceTags,
 		Check: &api.AgentServiceCheck{
-			HTTP:     checkURL,
-			Interval: cfg.CheckInterval.String(),
-			Timeout:  cfg.CheckTimeout.String(),
+			HTTP:          checkURL,
+			Interval:      cfg.CheckInterval.String(),
+			Timeout:       cfg.CheckTimeout.String(),
+			TLSSkipVerify: cfg.CheckTLSSkipVerify,
 		},
 	}
 


### PR DESCRIPTION
When serving the UI/API over HTTPS, the fabio consul health check will most likely fail as it's trying to connect to the page over its IP. Most certificates don't include IP SANs. This flag allows users to toggle whether or not to skip TLS verification for this particular check.

Edit: This will require [Consul >= 0.7.2](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#072-december-19-2016)
hashicorp/consul#1984
hashicorp/consul#2530