### PR TITLE
Use scheme() throughout addHeaders

### DIFF
--- a/proxy/http_headers.go
+++ b/proxy/http_headers.go
@@ -54,17 +54,7 @@ func addHeaders(r *http.Request, cfg config.Proxy) error {
 
 	fwd := r.Header.Get("Forwarded")
 	if fwd == "" {
-		fwd = "for=" + remoteIP
-		switch {
-		case ws && r.TLS != nil:
-			fwd += "; proto=wss"
-		case ws && r.TLS == nil:
-			fwd += "; proto=ws"
-		case r.TLS != nil:
-			fwd += "; proto=https"
-		default:
-			fwd += "; proto=http"
-		}
+		fwd = "for=" + remoteIP + "; proto=" + scheme(r)
 	}
 	if cfg.LocalIP != "" {
 		fwd += "; by=" + cfg.LocalIP


### PR DESCRIPTION
Noticed while adding some new headers that there was a bit of duplicated code. To avoid mangling everything into one pull request, I made a separate one.

Tests were running ok on this change:
```
cloud@fabio:~/go/src/github.com/fabiolb/fabio/proxy$ go test
2017/04/26 13:18:08 [INFO] cert: Store has certificates for ["example.com"]
PASS
ok  	github.com/fabiolb/fabio/proxy	0.576s
```