### PR TITLE
Make tests work with vault 0.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_script:
   - mkdir -p $GOPATH/bin
   - wget --version
   - wget https://releases.hashicorp.com/consul/0.8.3/consul_0.8.3_linux_amd64.zip
-  - wget https://releases.hashicorp.com/vault/0.6.5/vault_0.6.5_linux_amd64.zip
+  - wget https://releases.hashicorp.com/vault/0.7.3/vault_0.7.3_linux_amd64.zip
   - unzip -d $GOPATH/bin consul_0.8.3_linux_amd64.zip
-  - unzip -d $GOPATH/bin vault_0.6.5_linux_amd64.zip
+  - unzip -d $GOPATH/bin vault_0.7.3_linux_amd64.zip
   - vault --version
   - consul --version

--- a/cert/source_test.go
+++ b/cert/source_test.go
@@ -325,7 +325,12 @@ func vaultServer(t *testing.T, addr, rootToken string) (*exec.Cmd, *vaultapi.Cli
 	}
 
 	policy := `
+	# Vault < 0.7
 	path "secret/fabio/cert" {
+	  capabilities = ["list"]
+	}
+	# Vault >= 0.7. Note the trailing slash.
+	path "secret/fabio/cert/" {
 	  capabilities = ["list"]
 	}
 


### PR DESCRIPTION
Starting with Vault 0.7 list operations always use paths with a trailing
slash, so the policy used in testing has to allow that path in addition
to the one without a trailing slash.

[Link to changelog](https://github.com/hashicorp/vault/blob/v0.7.0/CHANGELOG.md#070-early-access-final-release-march-21th-2017), see first item under DEPRECATIONS/CHANGES.

The github.com/hashicorp/vault/api package is outdated too. Let me know if you'd like me to update (although there is no particular reason to do so).