### PR TITLE
Issue #274: Avoid premature vault token renewals

### DIFF
--- a/cert/vault_source.go
+++ b/cert/vault_source.go
@@ -228,7 +228,7 @@ func (s *VaultSource) renewToken(c *api.Client) error {
 	case ttl < 2*s.Refresh:
 		// Renew the token if it isn't valid for two more refresh intervals.
 		break
-	case ttl < 1*time.Minute:
+	case ttl < time.Minute:
 		// Renew the token if it isn't valid for one more minute. This happens
 		// if s.Refresh is small, say one second. It is risky to renew the
 		// token just one or two seconds before expiration; networks are


### PR DESCRIPTION
Don't attempt Vault token renewals if the token isn't renewable. If it
is, don't renew the token with each refresh; only do so if the token
would expire shortly. Increase the token's lifetime by its original TTL.

This now requires the "read" capability for the "auth/token/lookup-self" path in Vault. That is granted by default to all tokens. If the lookup-self request fails for any reason, fabio will assume that the token is not renewable.

No new configuration is required. Automatic renewal will work as long as the refresh interval is smaller than the token TTL, same as before.