### PR TITLE
Vault PKI cert source

### DIFF
--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -152,3 +152,8 @@ github.com/rogpeppe/fastuuid
 https://github.com/rogpeppe/fastuuid.git
 License: BSD 3-clause (https://github.com/google/uuid/LICENSE)
 Copyright © 2014, Roger Peppe All rights reserved.
+
+golang.org/x/sync/singleflight
+https://golang.org/x/sync/singleflight
+License: BSD 3-clause (https://golang.org/x/sync/LICENSE)
+Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/cert/source.go
+++ b/cert/source.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
 
 	"github.com/fabiolb/fabio/config"
 	"golang.org/x/sync/singleflight"
@@ -67,13 +66,20 @@ func NewSource(cfg config.CertSource) (Source, error) {
 
 	case "vault":
 		return &VaultSource{
-			Addr:         os.Getenv("VAULT_ADDR"),
 			CertPath:     cfg.CertPath,
 			ClientCAPath: cfg.ClientCAPath,
 			CAUpgradeCN:  cfg.CAUpgradeCN,
 			Refresh:      cfg.Refresh,
-			vaultToken:   os.Getenv("VAULT_TOKEN"),
+			Client:       DefaultVaultClient,
 		}, nil
+	case "vault-pki":
+		src := NewVaultPKISource()
+		src.CertPath = cfg.CertPath
+		src.ClientCAPath = cfg.ClientCAPath
+		src.CAUpgradeCN = cfg.CAUpgradeCN
+		src.Refresh = cfg.Refresh
+		src.Client = DefaultVaultClient
+		return src, nil
 
 	default:
 		return nil, fmt.Errorf("invalid certificate source %q", cfg.Type)

--- a/cert/source_test.go
+++ b/cert/source_test.go
@@ -140,8 +140,7 @@ func TestNewSource(t *testing.T) {
 			desc: "vault",
 			cfg:  certsource("vault"),
 			src: &VaultSource{
-				Addr:         os.Getenv("VAULT_ADDR"),
-				vaultToken:   os.Getenv("VAULT_TOKEN"),
+				Client:       DefaultVaultClient,
 				CertPath:     "cert",
 				ClientCAPath: "clientca",
 				CAUpgradeCN:  "upgcn",
@@ -339,6 +338,10 @@ func vaultServer(t *testing.T, addr, rootToken string) (*exec.Cmd, *vaultapi.Cli
 	path "secret/fabio/cert/*" {
 	  capabilities = ["read"]
 	}
+
+	path "test-pki/issue/fabio" {
+	  capabilities = ["update"]
+	}
 	`
 
 	if err := c.Sys().PutPolicy("fabio", policy); err != nil {
@@ -371,6 +374,43 @@ func makeToken(t *testing.T, c *vaultapi.Client, wrapTTL string, req *vaultapi.T
 	return resp.Auth.ClientToken
 }
 
+var vaultTestCases = []struct {
+	desc     string
+	wrapTTL  string
+	req      *vaultapi.TokenCreateRequest
+	dropWarn bool
+}{
+	{
+		desc: "renewable token",
+		req:  &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Policies: []string{"fabio"}},
+	},
+	{
+		desc:     "non-renewable token",
+		req:      &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Renewable: new(bool), Policies: []string{"fabio"}},
+		dropWarn: true,
+	},
+	{
+		desc: "renewable orphan token",
+		req:  &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", NoParent: true, Policies: []string{"fabio"}},
+	},
+	{
+		desc:     "non-renewable orphan token",
+		req:      &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", NoParent: true, Renewable: new(bool), Policies: []string{"fabio"}},
+		dropWarn: true,
+	},
+	{
+		desc:    "renewable wrapped token",
+		wrapTTL: "10s",
+		req:     &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Policies: []string{"fabio"}},
+	},
+	{
+		desc:     "non-renewable wrapped token",
+		wrapTTL:  "10s",
+		req:      &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Renewable: new(bool), Policies: []string{"fabio"}},
+		dropWarn: true,
+	},
+}
+
 func TestVaultSource(t *testing.T) {
 	const (
 		addr      = "127.0.0.1:58421"
@@ -389,61 +429,87 @@ func TestVaultSource(t *testing.T) {
 		t.Fatalf("logical.Write failed: %s", err)
 	}
 
-	newBool := func(b bool) *bool { return &b }
-
-	// run tests
-	tests := []struct {
-		desc     string
-		wrapTTL  string
-		req      *vaultapi.TokenCreateRequest
-		dropWarn bool
-	}{
-		{
-			desc: "renewable token",
-			req:  &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Policies: []string{"fabio"}},
-		},
-		{
-			desc:     "non-renewable token",
-			req:      &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Renewable: newBool(false), Policies: []string{"fabio"}},
-			dropWarn: true,
-		},
-		{
-			desc: "renewable orphan token",
-			req:  &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", NoParent: true, Policies: []string{"fabio"}},
-		},
-		{
-			desc:     "non-renewable orphan token",
-			req:      &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", NoParent: true, Renewable: newBool(false), Policies: []string{"fabio"}},
-			dropWarn: true,
-		},
-		{
-			desc:    "renewable wrapped token",
-			wrapTTL: "10s",
-			req:     &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Policies: []string{"fabio"}},
-		},
-		{
-			desc:     "non-renewable wrapped token",
-			wrapTTL:  "10s",
-			req:      &vaultapi.TokenCreateRequest{Lease: "1m", TTL: "1m", Renewable: newBool(false), Policies: []string{"fabio"}},
-			dropWarn: true,
-		},
-	}
-
 	pool := makeCertPool(certPEM)
 	timeout := 500 * time.Millisecond
-	for _, tt := range tests {
+	for _, tt := range vaultTestCases {
 		tt := tt // capture loop var
 		t.Run(tt.desc, func(t *testing.T) {
 			src := &VaultSource{
-				Addr:       "http://" + addr,
-				CertPath:   certPath,
-				vaultToken: makeToken(t, client, tt.wrapTTL, tt.req),
+				Client: &vaultClient{
+					addr:  "http://" + addr,
+					token: makeToken(t, client, tt.wrapTTL, tt.req),
+				},
+				CertPath: certPath,
 			}
 
 			// suppress the log warning about a non-renewable token
 			// since this is the expected behavior.
 			dropNotRenewableWarning = tt.dropWarn
 			testSource(t, src, pool, timeout)
+			dropNotRenewableWarning = false
+		})
+	}
+}
+
+func TestVaultPKISource(t *testing.T) {
+	const (
+		addr      = "127.0.0.1:58421"
+		rootToken = "token"
+		certPath  = "test-pki/issue/fabio"
+	)
+
+	// start a vault server
+	vault, client := vaultServer(t, addr, rootToken)
+	defer vault.Process.Kill()
+
+	// mount the PKI backend
+	err := client.Sys().Mount("test-pki", &vaultapi.MountInput{
+		Type: "pki",
+		Config: vaultapi.MountConfigInput{
+			DefaultLeaseTTL: "1h", // default validity period of issued certificates
+			MaxLeaseTTL:     "2h", // maximum validity period of issued certificates
+		},
+	})
+	if err != nil {
+		t.Fatalf("Mount pki backend failed: %s", err)
+	}
+
+	// generate root CA cert
+	resp, err := client.Logical().Write("test-pki/root/generate/internal", map[string]interface{}{
+		"common_name": "Fabio Test CA",
+		"ttl":         "2h",
+	})
+	if err != nil {
+		t.Fatalf("Generate root failed: %s", err)
+	}
+	caPool := makeCertPool([]byte(resp.Data["certificate"].(string)))
+
+	// create role
+	role := filepath.Base(certPath)
+	_, err = client.Logical().Write("test-pki/roles/"+role, map[string]interface{}{
+		"allowed_domains": "",
+		"allow_localhost": true,
+		"allow_ip_sans":   true,
+		"organization":    "Fabio Test",
+	})
+	if err != nil {
+		t.Fatalf("Write role failed: %s", err)
+	}
+
+	for _, tt := range vaultTestCases {
+		tt := tt // capture loop var
+		t.Run(tt.desc, func(t *testing.T) {
+			src := NewVaultPKISource()
+			src.Client = &vaultClient{
+				addr:  "http://" + addr,
+				token: makeToken(t, client, tt.wrapTTL, tt.req),
+			}
+			src.CertPath = certPath
+
+			// suppress the log warning about a non-renewable token
+			// since this is the expected behavior.
+			dropNotRenewableWarning = tt.dropWarn
+			testSource(t, src, caPool, 0)
 			dropNotRenewableWarning = false
 		})
 	}

--- a/cert/store.go
+++ b/cert/store.go
@@ -38,9 +38,11 @@ func (s *Store) certstore() certstore {
 	return s.cs.Load().(certstore)
 }
 
+var ErrNoCertsStored = errors.New("cert: no certificates stored")
+
 func getCertificate(cs certstore, clientHello *tls.ClientHelloInfo, strictMatch bool) (cert *tls.Certificate, err error) {
 	if len(cs.Certificates) == 0 {
-		return nil, errors.New("cert: no certificates stored")
+		return nil, ErrNoCertsStored
 	}
 
 	// There's only one choice, so no point doing any work.

--- a/cert/vault_client.go
+++ b/cert/vault_client.go
@@ -1,0 +1,134 @@
+package cert
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// vaultClient wraps an *api.Client and takes care of token renewal
+// automatically.
+type vaultClient struct {
+	addr  string // overrides the default config
+	token string // overrides the VAULT_TOKEN environment variable
+
+	client *api.Client
+	mu     sync.Mutex
+}
+
+var DefaultVaultClient = &vaultClient{}
+
+func (c *vaultClient) Get() (*api.Client, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client != nil {
+		return c.client, nil
+	}
+
+	conf := api.DefaultConfig()
+	if err := conf.ReadEnvironment(); err != nil {
+		return nil, err
+	}
+
+	if c.addr != "" {
+		conf.Address = c.addr
+	}
+
+	client, err := api.NewClient(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.token != "" {
+		client.SetToken(c.token)
+	}
+
+	token := client.Token()
+	if token == "" {
+		return nil, errors.New("vault: no token")
+	}
+
+	// did we get a wrapped token?
+	resp, err := client.Logical().Unwrap(token)
+	switch {
+	case err == nil:
+		log.Printf("[INFO] vault: Unwrapped token %s", token)
+		client.SetToken(resp.Auth.ClientToken)
+	case strings.HasPrefix(err.Error(), "no value found at"):
+		// not a wrapped token
+	default:
+		return nil, err
+	}
+
+	c.client = client
+	go c.keepTokenAlive()
+
+	return client, nil
+}
+
+// dropNotRenewableWarning controls whether the 'Token is not renewable'
+// warning is logged. This is useful for testing where this is the expected
+// behavior. On production, this should always be set to false.
+var dropNotRenewableWarning bool
+
+func (c *vaultClient) keepTokenAlive() {
+	resp, err := c.client.Auth().Token().LookupSelf()
+	if err != nil {
+		log.Printf("[WARN] vault: lookup-self failed, token renewal is disabled: %s", err)
+		return
+	}
+
+	b, _ := json.Marshal(resp.Data)
+	var data struct {
+		TTL         int       `json:"ttl"`
+		CreationTTL int       `json:"creation_ttl"`
+		Renewable   bool      `json:"renewable"`
+		ExpireTime  time.Time `json:"expire_time"`
+	}
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Printf("[WARN] vault: lookup-self failed, token renewal is disabled: %s", err)
+		return
+	}
+
+	switch {
+	case data.Renewable:
+		// no-op
+	case data.ExpireTime.IsZero():
+		// token doesn't expire
+		return
+	case dropNotRenewableWarning:
+		return
+	default:
+		ttl := time.Until(data.ExpireTime)
+		ttl = ttl / time.Second * time.Second // truncate to seconds
+		log.Printf("[WARN] vault: Token is not renewable and will expire %s from now at %s",
+			ttl, data.ExpireTime.Format(time.RFC3339))
+		return
+	}
+
+	ttl := time.Duration(data.TTL) * time.Second
+	timer := time.NewTimer(ttl / 2)
+
+	for range timer.C {
+		resp, err := c.client.Auth().Token().RenewSelf(data.CreationTTL)
+		if err != nil {
+			log.Printf("[WARN] vault: Failed to renew token: %s", err)
+			timer.Reset(time.Second) // TODO: backoff? abort after N consecutive failures?
+			continue
+		}
+
+		if !resp.Auth.Renewable || resp.Auth.LeaseDuration == 0 {
+			// token isn't renewable anymore, we're done.
+			return
+		}
+
+		ttl = time.Duration(resp.Auth.LeaseDuration) * time.Second
+		timer.Reset(ttl / 2)
+	}
+}

--- a/cert/vault_pki_source.go
+++ b/cert/vault_pki_source.go
@@ -1,0 +1,145 @@
+package cert
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"sync"
+	"time"
+)
+
+// VaultPKISource implements a certificate source which issues TLS certificates
+// on-demand using a Vault PKI backend. Client authorization certificates are
+// loaded from a generic backend (same as in VaultSource). The Vault token
+// should be set through the VAULT_TOKEN environment variable.
+//
+// The TLS certificates are re-issued automatically before they expire.
+type VaultPKISource struct {
+	Client       *vaultClient
+	CertPath     string
+	ClientCAPath string
+	CAUpgradeCN  string
+
+	// Re-issue certificates this long before they expire. Cannot be less then
+	// one hour.
+	Refresh time.Duration
+
+	certsCh chan []tls.Certificate
+
+	mu    sync.Mutex
+	certs map[string]tls.Certificate // issued certs
+}
+
+func NewVaultPKISource() *VaultPKISource {
+	return &VaultPKISource{
+		certs:   make(map[string]tls.Certificate, 0),
+		certsCh: make(chan []tls.Certificate, 1),
+	}
+}
+
+func (s *VaultPKISource) LoadClientCAs() (*x509.CertPool, error) {
+	return (&VaultSource{
+		Client:       s.Client,
+		ClientCAPath: s.ClientCAPath,
+		CAUpgradeCN:  s.CAUpgradeCN,
+	}).LoadClientCAs()
+}
+
+func (s *VaultPKISource) Certificates() chan []tls.Certificate {
+	return s.certsCh
+}
+
+func (s *VaultPKISource) Issue(commonName string) (*tls.Certificate, error) {
+	c, err := s.Client.Get()
+	if err != nil {
+		return nil, fmt.Errorf("vault: client: %s", err)
+	}
+
+	resp, err := c.Logical().Write(s.CertPath, map[string]interface{}{
+		"common_name": commonName,
+	})
+	if err != nil {
+		fmt.Printf("Issue: %v\n", err)
+		return nil, fmt.Errorf("vault: issue: %s", err)
+	}
+
+	b, _ := json.Marshal(resp.Data)
+	var data struct {
+		PrivateKey  string   `json:"private_key"`
+		Certificate string   `json:"certificate"`
+		CAChain     []string `json:"ca_chain"`
+	}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, fmt.Errorf("vault: issue: %s", err)
+	}
+
+	if data.PrivateKey == "" {
+		return nil, fmt.Errorf("vault: issue: missing private key")
+	}
+	if data.Certificate == "" {
+		return nil, fmt.Errorf("vault: issue: missing certificate")
+	}
+
+	key := []byte(data.PrivateKey)
+	fullChain := []byte(data.Certificate)
+	for _, c := range data.CAChain {
+		fullChain = append(fullChain, '\n')
+		fullChain = append(fullChain, []byte(c)...)
+	}
+
+	cert, err := tls.X509KeyPair(fullChain, key)
+	if err != nil {
+		return nil, fmt.Errorf("vault: issue: %s", err)
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		// Should never happen because x509.ParseCertificate did this
+		// successfully already, but threw the result away.
+		return nil, fmt.Errorf("vault: issue: %s", err)
+	}
+
+	refresh := s.Refresh
+	if refresh < time.Hour {
+		refresh = time.Hour
+	}
+
+	expires := x509Cert.NotAfter
+	certTTL := time.Until(expires) - refresh
+	time.AfterFunc(certTTL, func() {
+		_, err := s.Issue(commonName)
+		if err != nil {
+			log.Printf("[ERROR] cert: vault: Failed to re-issue cert for %s: %s", commonName, err)
+			// TODO: Now what? Retry? Do nothing?
+			return
+		}
+	})
+
+	s.mu.Lock()
+	s.certs[commonName] = cert
+	allCerts := make([]tls.Certificate, 0, len(s.certs))
+	for _, c := range s.certs {
+		allCerts = append(allCerts, c)
+	}
+	s.mu.Unlock()
+
+	go func() { s.certsCh <- allCerts }()
+	log.Printf("[INFO] cert: vault: issued cert for %s; serial = %s", commonName, s.formatSerial(x509Cert.SerialNumber))
+
+	return &cert, nil
+}
+
+func (*VaultPKISource) formatSerial(sn *big.Int) string {
+	var buf bytes.Buffer
+	for _, b := range sn.Bytes() {
+		if buf.Len() > 0 {
+			buf.WriteByte('-')
+		}
+		fmt.Fprintf(&buf, "%02x", b)
+	}
+	return buf.String()
+}

--- a/config/load.go
+++ b/config/load.go
@@ -371,7 +371,7 @@ func parseListen(cfg map[string]string, cs map[string]CertSource, readTimeout, w
 	if cs[csName].Type == "vault-pki" && !l.StrictMatch {
 		// Without StrictMatch the first issued certificate is used for all
 		// subsequent requests, even if the common name doesn't match.
-		log.Print("[INFO] vault-pki requires strictmatch; enabling strictmatch for listener %q", l.Addr)
+		log.Printf("[INFO] vault-pki requires strictmatch; enabling strictmatch for listener %s", l.Addr)
 		l.StrictMatch = true
 	}
 

--- a/config/load.go
+++ b/config/load.go
@@ -368,6 +368,12 @@ func parseListen(cfg map[string]string, cs map[string]CertSource, readTimeout, w
 	if csName == "" && l.Proto == "https" {
 		return Listen{}, fmt.Errorf("proto 'https' requires cert source")
 	}
+	if cs[csName].Type == "vault-pki" && !l.StrictMatch {
+		// Without StrictMatch the first issued certificate is used for all
+		// subsequent requests, even if the common name doesn't match.
+		log.Print("[INFO] vault-pki requires strictmatch; enabling strictmatch for listener %q", l.Addr)
+		l.StrictMatch = true
+	}
 
 	return
 }
@@ -497,17 +503,19 @@ func parseCertSource(cfg map[string]string) (c CertSource, err error) {
 	if c.Name == "" {
 		return CertSource{}, fmt.Errorf("missing 'cs' in %s", cfg)
 	}
-	if c.Type == "" {
-		return CertSource{}, fmt.Errorf("missing 'type' in %s", cfg)
-	}
 	if c.CertPath == "" {
 		return CertSource{}, fmt.Errorf("missing 'cert' in %s", cfg)
 	}
-	if c.Type != "file" && c.Type != "path" && c.Type != "http" && c.Type != "consul" && c.Type != "vault" {
+	switch c.Type {
+	case "":
+		return CertSource{}, fmt.Errorf("missing 'type' in %s", cfg)
+	case "file", "consul":
+		c.Refresh = 0
+	case "path", "http", "vault", "vault-pki":
+		// no-op
+	default:
 		return CertSource{}, fmt.Errorf("unknown cert source type %s", c.Type)
 	}
-	if c.Type == "file" || c.Type == "consul" {
-		c.Refresh = 0
-	}
+
 	return
 }

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -173,6 +173,32 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			desc: "-proxy.addr with vault-pki cert source",
+			args: []string{
+				"-proxy.addr", ":5555;cs=name",
+				"-proxy.cs", "cs=name;type=vault-pki;cert=pki/issue/value",
+			},
+			cfg: func(cfg *Config) *Config {
+				cfg.Listen = []Listen{Listen{Addr: ":5555", Proto: "https"}}
+				cfg.Listen[0].CertSource = CertSource{Name: "name", Type: "vault-pki", CertPath: "pki/issue/value", Refresh: 3 * time.Second}
+				cfg.Listen[0].StrictMatch = true // implicit
+				return cfg
+			},
+		},
+		{
+			desc: "-proxy.addr with vault-pki cert source, -proxy.cs first",
+			args: []string{
+				"-proxy.cs", "cs=name;type=vault-pki;cert=pki/issue/value",
+				"-proxy.addr", ":5555;cs=name",
+			},
+			cfg: func(cfg *Config) *Config {
+				cfg.Listen = []Listen{Listen{Addr: ":5555", Proto: "https"}}
+				cfg.Listen[0].CertSource = CertSource{Name: "name", Type: "vault-pki", CertPath: "pki/issue/value", Refresh: 3 * time.Second}
+				cfg.Listen[0].StrictMatch = true // implicit
+				return cfg
+			},
+		},
+		{
 			desc: "-proxy.addr with cert source",
 			args: []string{"-proxy.addr", ":5555;cs=name;strictmatch=true", "-proxy.cs", "cs=name;type=path;cert=foo;clientca=bar;refresh=2s;hdr=a: b;caupgcn=furb"},
 			cfg: func(cfg *Config) *Config {

--- a/fabio.properties
+++ b/fabio.properties
@@ -119,6 +119,23 @@
 #
 #   cs=<name>;type=vault;cert=secret/fabio/certs
 #
+# Vault PKI
+#
+# The Vault PKI certificate store uses HashiCorp Vault's PKI backend to issue
+# certificates on-demand.
+#
+# The 'cert' option provides a PKI backend path for issuing certificates. The
+# 'clientca' option works in the same way as for the generic Vault source.
+#
+# The 'refresh' option determines how long before the expiration date
+# certificates are re-issued. Values smaller than one hour are silently changed
+# to one hour, which is also the default.
+#
+#   cs=<name>;type=vault-pki;cert=pki/issue/example-dot-com;refresh=24h;clientca=secret/fabio/client-certs
+#
+# This source will issue server certificates on-demand using the PKI backend
+# and re-issue them 24 hours before they expire. The CA for client
+# authentication is expected to be stored at secret/fabio/client-certs.
 #
 # Common options
 #
@@ -149,6 +166,9 @@
 #
 #     # Vault certificate source
 #     proxy.cs = cs=some-name;type=vault;cert=secret/fabio/certs
+
+#     # Vault PKI certificate source
+#     proxy.cs = cs=some-name;type=vault-pki;cert=pki/issue/example-dot-com
 #
 #     # Multiple certificate sources
 #     proxy.cs = cs=srcA;type=path;path=path/to/certs,\

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -1,0 +1,111 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight // import "golang.org/x/sync/singleflight"
+
+import "sync"
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	delete(g.m, key)
+	for _, ch := range c.chans {
+		ch <- Result{c.val, c.err, c.dups > 0}
+	}
+	g.mu.Unlock()
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2,45 +2,252 @@
 	"comment": "",
 	"ignore": "test",
 	"package": [
-		{"path":"github.com/armon/go-proxyproto","checksumSHA1":"eAall4ACaMG40mzSJ5Oc95GiF1A=","revision":"609d6338d3a76ec26ac3fe7045a164d9a58436e7","revisionTime":"2015-02-06T18:58:55-08:00"},
-		{"path":"github.com/circonus-labs/circonus-gometrics","checksumSHA1":"ZAdLZ0e/hin4AXxdS9F8y0yi/bg=","revision":"f8c68ed96a065c10344dcaf802f608781fc0a981","revisionTime":"2016-08-30T16:47:25Z"},
-		{"path":"github.com/circonus-labs/circonus-gometrics/api","checksumSHA1":"2hV0W0wM75u+OJ4kGv0i7B95cmY=","revision":"f8c68ed96a065c10344dcaf802f608781fc0a981","revisionTime":"2016-08-30T16:47:25Z"},
-		{"path":"github.com/circonus-labs/circonus-gometrics/checkmgr","checksumSHA1":"r3XLF0s89Y7UJgS9YP3NbdyafNY=","revision":"f8c68ed96a065c10344dcaf802f608781fc0a981","revisionTime":"2016-08-30T16:47:25Z"},
-		{"path":"github.com/circonus-labs/circonusllhist","checksumSHA1":"C4Z7+l5GOpOCW5DcvNYzheGvQRE=","revision":"d724266ae5270ae8b87a5d2e8081f04e307c3c18","revisionTime":"2016-05-26T04:38:13Z"},
-		{"path":"github.com/cyberdelia/go-metrics-graphite","checksumSHA1":"8/Q1JbAHUmL4sDURLq6yron4K/I=","revision":"b8345b7f01d571b05366d5791a034d872f1bb36f","revisionTime":"2015-08-25T20:22:00-07:00"},
-		{"path":"github.com/fatih/structs","checksumSHA1":"zKLQNNEpgfrJOwVrDDyBMYEIx/w=","revision":"5ada2f449b108d87dbd8c1e60c32cdd065c27886","revisionTime":"2016-06-01T09:31:17Z"},
-		{"path":"github.com/hashicorp/consul/api","checksumSHA1":"GsJ84gKbQno8KbojhVTgSVWNues=","revision":"402636ff2db998edef392ac6d59210d2170b3ebf","revisionTime":"2017-04-05T04:22:14Z","version":"v0.8.0","versionExact":"v0.8.0"},
-		{"path":"github.com/hashicorp/errwrap","checksumSHA1":"cdOCt0Yb+hdErz8NAQqayxPmRsY=","revision":"7554cd9344cec97297fa6649b055a8c98c2a1e55","revisionTime":"2014-10-27T22:47:10-07:00"},
-		{"path":"github.com/hashicorp/go-cleanhttp","checksumSHA1":"Uzyon2091lmwacNsl1hCytjhHtg=","revision":"ad28ea4487f05916463e2423a55166280e8254b5","revisionTime":"2016-04-07T17:41:26Z"},
-		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"lrSl49G23l6NhfilxPM0XFs5rZo=","revision":"d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5","revisionTime":"2015-09-16T13:57:42-07:00"},
-		{"path":"github.com/hashicorp/go-retryablehttp","checksumSHA1":"GBDE1KDl/7c5hlRPYRZ7+C0WQ0g=","revision":"f4ed9b0fa01a2ac614afe7c897ed2e3d8208f3e8","revisionTime":"2016-08-10T17:22:55Z"},
-		{"path":"github.com/hashicorp/go-rootcerts","checksumSHA1":"A1PcINvF3UiwHRKn8UcgARgvGRs=","revision":"6bb64b370b90e7ef1fa532be9e591a81c3493e00","revisionTime":"2016-05-03T09:34:40-05:00"},
-		{"path":"github.com/hashicorp/hcl","checksumSHA1":"5LrCq/ydlbL6pq1cdmuxiw7QV98=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/ast","checksumSHA1":"WP5ODRo9+USuAsKYPu5RW3q8Epg=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/parser","checksumSHA1":"SVw0qm83Anf5T2GkYabn+f7Ibv0=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/scanner","checksumSHA1":"WZM0q7Sya8PcGj607x1npgcEPa4=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/strconv","checksumSHA1":"ETy6J7OZ7zjBNq0V0Lm8E/7Xafw=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/token","checksumSHA1":"VGNVyGYDGTTCTRqGH5R+CL0u6xw=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/json/parser","checksumSHA1":"uEaK2zagnGctsUmjWt8ZYmK1Yvs=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/json/scanner","checksumSHA1":"S1e0F9ZKSnqgOLfjDTYazRL28tA=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/hcl/json/token","checksumSHA1":"fNlXQCQEnb+B3k5UDL/r15xtSJY=","revision":"d7400db7143f8e869812e50a53acd6c8d92af3b8","revisionTime":"2016-06-07T00:19:40Z"},
-		{"path":"github.com/hashicorp/serf/coordinate","checksumSHA1":"o8In5byYGDCY/mnTuV4Tfmci+3w=","revision":"0df3e3df1703f838243a7f3f12bf0b88566ade5a","revisionTime":"2015-12-21T18:49:50Z","version":"v0.6.4","versionExact":"v0.6.4"},
-		{"path":"github.com/hashicorp/vault/api","checksumSHA1":"9/RHDTjqflfK3/f2Tfvwx+82I40=","revision":"f627c01df8d7bebb403cf899ca1beb24f5fc84cd","revisionTime":"2016-06-14T07:51:08Z","version":"v0.6.0","versionExact":"v0.6.0"},
-		{"path":"github.com/magiconair/go-metrics-statsd","checksumSHA1":"1I3MjrGSOw5rPtlrHcGI8bJfLyA=","revision":"380638b554e36fe109711b41e09917d94b235e86","revisionTime":"2017-01-25T16:17:32Z"},
-		{"path":"github.com/magiconair/properties","checksumSHA1":"eqs9e0Fw1wlUZCj/ZtrSwnPsJ54=","revision":"c265cfa48dda6474e208715ca93e987829f572f8","revisionTime":"2016-03-20T21:54:47+01:00"},
-		{"path":"github.com/mitchellh/go-homedir","checksumSHA1":"AXacfEchaUqT5RGmPmMXsOWRhv8=","revision":"1111e456ffea841564ac0fa5f69c26ef44dafec9","revisionTime":"2016-06-06T03:01:22Z"},
-		{"path":"github.com/mitchellh/mapstructure","checksumSHA1":"KCJhN9Dx329wAN/SeL4CxeypPyk=","revision":"d2dd0262208475919e1a362f675cfc0e7c10e905","revisionTime":"2016-02-11T19:18:39-08:00"},
-		{"path":"github.com/pascaldekloe/goe/verify","checksumSHA1":"4tr8yNUt5DB8GXc5y+uq6J7TJ54=","revision":"f99183613f483cd9b8c79359d572836e243e0763","revisionTime":"2015-07-19T21:56:08+02:00"},
-		{"path":"github.com/pkg/profile","checksumSHA1":"C3yiSMdTQxSY3xqKJzMV9T+KnIc=","revision":"5b67d428864e92711fcbd2f8629456121a56d91f","revisionTime":"2017-05-09T09:25:25Z"},
-		{"path":"github.com/rcrowley/go-metrics","checksumSHA1":"ODTWX4h8f+DW3oWZFT0yTmfHzdg=","revision":"3e5e593311103d49927c8d2b0fd93ccdfe4a525c","revisionTime":"2015-07-19T09:56:14-07:00"},
-		{"path":"github.com/rogpeppe/fastuuid","checksumSHA1":"ehRkDJisGCCSYdNgyvs1gSywSPE=","revision":"6724a57986aff9bff1a1770e9347036def7c89f6","revisionTime":"2015-01-06T09:31:45Z"},
-		{"path":"github.com/ryanuber/go-glob","checksumSHA1":"EYkx4sXDLSEd1xUtGoXRsfd5cpw=","revision":"572520ed46dbddaed19ea3d9541bdd0494163693","revisionTime":"2016-02-26T08:37:05Z"},
-		{"path":"github.com/sergi/go-diff/diffmatchpatch","checksumSHA1":"iWCtyR1TkJ22Bi/ygzfKDvOQdQY=","revision":"24e2351369ec4949b2ed0dc5c477afdd4c4034e8","revisionTime":"2017-01-18T13:12:30Z"},
-		{"path":"golang.org/x/net/http2","checksumSHA1":"N1akwAdrHVfPPrsFOhG2ouP21VA=","revision":"f2499483f923065a842d38eb4c7f1927e6fc6e6d","revisionTime":"2017-01-14T04:22:49Z"},
-		{"path":"golang.org/x/net/http2/hpack","checksumSHA1":"HzuGD7AwgC0p1az1WAQnEFnEk98=","revision":"f2499483f923065a842d38eb4c7f1927e6fc6e6d","revisionTime":"2017-01-14T04:22:49Z"},
-		{"path":"golang.org/x/net/idna","checksumSHA1":"GIGmSrYACByf5JDIP9ByBZksY80=","revision":"f2499483f923065a842d38eb4c7f1927e6fc6e6d","revisionTime":"2017-01-14T04:22:49Z"},
-		{"path":"golang.org/x/net/lex/httplex","checksumSHA1":"3xyuaSNmClqG4YWC7g0isQIbUTc=","revision":"f2499483f923065a842d38eb4c7f1927e6fc6e6d","revisionTime":"2017-01-14T04:22:49Z"},
-		{"path":"golang.org/x/net/websocket","checksumSHA1":"xvuVB+aMh4udpinGsmtK31pcWC0=","revision":"9946ad7d5eae91d8edca4f54d1a1e130a052e823","revisionTime":"2015-10-20T22:50:55Z"}
+		{
+			"checksumSHA1": "eAall4ACaMG40mzSJ5Oc95GiF1A=",
+			"path": "github.com/armon/go-proxyproto",
+			"revision": "609d6338d3a76ec26ac3fe7045a164d9a58436e7",
+			"revisionTime": "2015-02-06T18:58:55-08:00"
+		},
+		{
+			"checksumSHA1": "ZAdLZ0e/hin4AXxdS9F8y0yi/bg=",
+			"path": "github.com/circonus-labs/circonus-gometrics",
+			"revision": "f8c68ed96a065c10344dcaf802f608781fc0a981",
+			"revisionTime": "2016-08-30T16:47:25Z"
+		},
+		{
+			"checksumSHA1": "2hV0W0wM75u+OJ4kGv0i7B95cmY=",
+			"path": "github.com/circonus-labs/circonus-gometrics/api",
+			"revision": "f8c68ed96a065c10344dcaf802f608781fc0a981",
+			"revisionTime": "2016-08-30T16:47:25Z"
+		},
+		{
+			"checksumSHA1": "r3XLF0s89Y7UJgS9YP3NbdyafNY=",
+			"path": "github.com/circonus-labs/circonus-gometrics/checkmgr",
+			"revision": "f8c68ed96a065c10344dcaf802f608781fc0a981",
+			"revisionTime": "2016-08-30T16:47:25Z"
+		},
+		{
+			"checksumSHA1": "C4Z7+l5GOpOCW5DcvNYzheGvQRE=",
+			"path": "github.com/circonus-labs/circonusllhist",
+			"revision": "d724266ae5270ae8b87a5d2e8081f04e307c3c18",
+			"revisionTime": "2016-05-26T04:38:13Z"
+		},
+		{
+			"checksumSHA1": "8/Q1JbAHUmL4sDURLq6yron4K/I=",
+			"path": "github.com/cyberdelia/go-metrics-graphite",
+			"revision": "b8345b7f01d571b05366d5791a034d872f1bb36f",
+			"revisionTime": "2015-08-25T20:22:00-07:00"
+		},
+		{
+			"checksumSHA1": "zKLQNNEpgfrJOwVrDDyBMYEIx/w=",
+			"path": "github.com/fatih/structs",
+			"revision": "5ada2f449b108d87dbd8c1e60c32cdd065c27886",
+			"revisionTime": "2016-06-01T09:31:17Z"
+		},
+		{
+			"checksumSHA1": "GsJ84gKbQno8KbojhVTgSVWNues=",
+			"path": "github.com/hashicorp/consul/api",
+			"revision": "402636ff2db998edef392ac6d59210d2170b3ebf",
+			"revisionTime": "2017-04-05T04:22:14Z",
+			"version": "v0.8.0",
+			"versionExact": "v0.8.0"
+		},
+		{
+			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
+			"path": "github.com/hashicorp/errwrap",
+			"revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55",
+			"revisionTime": "2014-10-27T22:47:10-07:00"
+		},
+		{
+			"checksumSHA1": "Uzyon2091lmwacNsl1hCytjhHtg=",
+			"path": "github.com/hashicorp/go-cleanhttp",
+			"revision": "ad28ea4487f05916463e2423a55166280e8254b5",
+			"revisionTime": "2016-04-07T17:41:26Z"
+		},
+		{
+			"checksumSHA1": "lrSl49G23l6NhfilxPM0XFs5rZo=",
+			"path": "github.com/hashicorp/go-multierror",
+			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5",
+			"revisionTime": "2015-09-16T13:57:42-07:00"
+		},
+		{
+			"checksumSHA1": "GBDE1KDl/7c5hlRPYRZ7+C0WQ0g=",
+			"path": "github.com/hashicorp/go-retryablehttp",
+			"revision": "f4ed9b0fa01a2ac614afe7c897ed2e3d8208f3e8",
+			"revisionTime": "2016-08-10T17:22:55Z"
+		},
+		{
+			"checksumSHA1": "A1PcINvF3UiwHRKn8UcgARgvGRs=",
+			"path": "github.com/hashicorp/go-rootcerts",
+			"revision": "6bb64b370b90e7ef1fa532be9e591a81c3493e00",
+			"revisionTime": "2016-05-03T09:34:40-05:00"
+		},
+		{
+			"checksumSHA1": "5LrCq/ydlbL6pq1cdmuxiw7QV98=",
+			"path": "github.com/hashicorp/hcl",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "WP5ODRo9+USuAsKYPu5RW3q8Epg=",
+			"path": "github.com/hashicorp/hcl/hcl/ast",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "SVw0qm83Anf5T2GkYabn+f7Ibv0=",
+			"path": "github.com/hashicorp/hcl/hcl/parser",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "WZM0q7Sya8PcGj607x1npgcEPa4=",
+			"path": "github.com/hashicorp/hcl/hcl/scanner",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "ETy6J7OZ7zjBNq0V0Lm8E/7Xafw=",
+			"path": "github.com/hashicorp/hcl/hcl/strconv",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "VGNVyGYDGTTCTRqGH5R+CL0u6xw=",
+			"path": "github.com/hashicorp/hcl/hcl/token",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "uEaK2zagnGctsUmjWt8ZYmK1Yvs=",
+			"path": "github.com/hashicorp/hcl/json/parser",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "S1e0F9ZKSnqgOLfjDTYazRL28tA=",
+			"path": "github.com/hashicorp/hcl/json/scanner",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
+			"path": "github.com/hashicorp/hcl/json/token",
+			"revision": "d7400db7143f8e869812e50a53acd6c8d92af3b8",
+			"revisionTime": "2016-06-07T00:19:40Z"
+		},
+		{
+			"checksumSHA1": "o8In5byYGDCY/mnTuV4Tfmci+3w=",
+			"path": "github.com/hashicorp/serf/coordinate",
+			"revision": "0df3e3df1703f838243a7f3f12bf0b88566ade5a",
+			"revisionTime": "2015-12-21T18:49:50Z",
+			"version": "v0.6.4",
+			"versionExact": "v0.6.4"
+		},
+		{
+			"checksumSHA1": "9/RHDTjqflfK3/f2Tfvwx+82I40=",
+			"path": "github.com/hashicorp/vault/api",
+			"revision": "f627c01df8d7bebb403cf899ca1beb24f5fc84cd",
+			"revisionTime": "2016-06-14T07:51:08Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
+		},
+		{
+			"checksumSHA1": "1I3MjrGSOw5rPtlrHcGI8bJfLyA=",
+			"path": "github.com/magiconair/go-metrics-statsd",
+			"revision": "380638b554e36fe109711b41e09917d94b235e86",
+			"revisionTime": "2017-01-25T16:17:32Z"
+		},
+		{
+			"checksumSHA1": "eqs9e0Fw1wlUZCj/ZtrSwnPsJ54=",
+			"path": "github.com/magiconair/properties",
+			"revision": "c265cfa48dda6474e208715ca93e987829f572f8",
+			"revisionTime": "2016-03-20T21:54:47+01:00"
+		},
+		{
+			"checksumSHA1": "AXacfEchaUqT5RGmPmMXsOWRhv8=",
+			"path": "github.com/mitchellh/go-homedir",
+			"revision": "1111e456ffea841564ac0fa5f69c26ef44dafec9",
+			"revisionTime": "2016-06-06T03:01:22Z"
+		},
+		{
+			"checksumSHA1": "KCJhN9Dx329wAN/SeL4CxeypPyk=",
+			"path": "github.com/mitchellh/mapstructure",
+			"revision": "d2dd0262208475919e1a362f675cfc0e7c10e905",
+			"revisionTime": "2016-02-11T19:18:39-08:00"
+		},
+		{
+			"checksumSHA1": "4tr8yNUt5DB8GXc5y+uq6J7TJ54=",
+			"path": "github.com/pascaldekloe/goe/verify",
+			"revision": "f99183613f483cd9b8c79359d572836e243e0763",
+			"revisionTime": "2015-07-19T21:56:08+02:00"
+		},
+		{
+			"checksumSHA1": "C3yiSMdTQxSY3xqKJzMV9T+KnIc=",
+			"path": "github.com/pkg/profile",
+			"revision": "5b67d428864e92711fcbd2f8629456121a56d91f",
+			"revisionTime": "2017-05-09T09:25:25Z"
+		},
+		{
+			"checksumSHA1": "ODTWX4h8f+DW3oWZFT0yTmfHzdg=",
+			"path": "github.com/rcrowley/go-metrics",
+			"revision": "3e5e593311103d49927c8d2b0fd93ccdfe4a525c",
+			"revisionTime": "2015-07-19T09:56:14-07:00"
+		},
+		{
+			"checksumSHA1": "ehRkDJisGCCSYdNgyvs1gSywSPE=",
+			"path": "github.com/rogpeppe/fastuuid",
+			"revision": "6724a57986aff9bff1a1770e9347036def7c89f6",
+			"revisionTime": "2015-01-06T09:31:45Z"
+		},
+		{
+			"checksumSHA1": "EYkx4sXDLSEd1xUtGoXRsfd5cpw=",
+			"path": "github.com/ryanuber/go-glob",
+			"revision": "572520ed46dbddaed19ea3d9541bdd0494163693",
+			"revisionTime": "2016-02-26T08:37:05Z"
+		},
+		{
+			"checksumSHA1": "iWCtyR1TkJ22Bi/ygzfKDvOQdQY=",
+			"path": "github.com/sergi/go-diff/diffmatchpatch",
+			"revision": "24e2351369ec4949b2ed0dc5c477afdd4c4034e8",
+			"revisionTime": "2017-01-18T13:12:30Z"
+		},
+		{
+			"checksumSHA1": "N1akwAdrHVfPPrsFOhG2ouP21VA=",
+			"path": "golang.org/x/net/http2",
+			"revision": "f2499483f923065a842d38eb4c7f1927e6fc6e6d",
+			"revisionTime": "2017-01-14T04:22:49Z"
+		},
+		{
+			"checksumSHA1": "HzuGD7AwgC0p1az1WAQnEFnEk98=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "f2499483f923065a842d38eb4c7f1927e6fc6e6d",
+			"revisionTime": "2017-01-14T04:22:49Z"
+		},
+		{
+			"checksumSHA1": "GIGmSrYACByf5JDIP9ByBZksY80=",
+			"path": "golang.org/x/net/idna",
+			"revision": "f2499483f923065a842d38eb4c7f1927e6fc6e6d",
+			"revisionTime": "2017-01-14T04:22:49Z"
+		},
+		{
+			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
+			"path": "golang.org/x/net/lex/httplex",
+			"revision": "f2499483f923065a842d38eb4c7f1927e6fc6e6d",
+			"revisionTime": "2017-01-14T04:22:49Z"
+		},
+		{
+			"checksumSHA1": "xvuVB+aMh4udpinGsmtK31pcWC0=",
+			"path": "golang.org/x/net/websocket",
+			"revision": "9946ad7d5eae91d8edca4f54d1a1e130a052e823",
+			"revisionTime": "2015-10-20T22:50:55Z"
+		},
+		{
+			"checksumSHA1": "VhUZFUuhLFSBFUfskMC4am5RIdc=",
+			"path": "golang.org/x/sync/singleflight",
+			"revision": "8e0aa688b654ef28caa72506fa5ec8dba9fc7690",
+			"revisionTime": "2017-07-19T03:38:01Z"
+		}
 	],
 	"rootPath": "github.com/fabiolb/fabio"
 }


### PR DESCRIPTION
POC for the Vault PKI source. I have not tested this thoroughly yet, especially under load. I want to get feedback on the design first.

I moved the Vault client bits out of the existing vault source, so they can be shared with the new PKI source. I had to redo the token renewal, since that was triggered as part of the refresh logic. However, the PKI source will for the most part just sit and wait for certificates to expire. So I created a wrapper around the *api.Client, that will renew tokens after half their lifetime. This is the same behaviour as in Nomad and Consul Template, for instance.

I left a few TODO comments in the code. I'd appreciate your thoughts on those.

