### PR TITLE
Fix memory leak in tcp proxy

### DIFF
--- a/proxy/tcp/server.go
+++ b/proxy/tcp/server.go
@@ -80,7 +80,20 @@ func (s *Server) Serve(l net.Listener) error {
 		}
 		s.conns[c] = true
 		s.mu.Unlock()
-		go s.Handler.ServeTCP(c)
+
+		go func() {
+			defer func() {
+				// Explicitly close the connection
+				c.Close()
+
+				// Delete the connection from the conns map
+				s.mu.Lock()
+				delete(s.conns, c)
+				s.mu.Unlock()
+			}()
+
+			s.Handler.ServeTCP(c)
+		}()
 	}
 }
 


### PR DESCRIPTION
This patch wraps the ServeTCP to clean up old connections from the `s.conns` map