### PR TITLE
Resolves #327 PoC raw_statsd

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -66,6 +66,10 @@ func NewRegistry(cfg config.Metrics) (r Registry, err error) {
 		log.Printf("[INFO] Sending metrics to StatsD on %s as %q", cfg.StatsDAddr, prefix)
 		return gmStatsDRegistry(prefix, cfg.StatsDAddr, cfg.Interval)
 
+	case "raw_statsd":
+		log.Printf("[INFO] Sending raw metrics to StatsD on %s as %q", cfg.StatsDAddr, prefix)
+		return NewStatsdRegistry(prefix, cfg.StatsDAddr), nil
+
 	case "circonus":
 		return circonusRegistry(prefix, cfg.Circonus, cfg.Interval)
 

--- a/metrics/statsd.go
+++ b/metrics/statsd.go
@@ -1,0 +1,120 @@
+package metrics
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"time"
+)
+
+type StatsdRegistry struct {
+	addr   string
+	prefix string
+	conn   net.Conn
+}
+
+func NewStatsdRegistry(prefix, addr string) *StatsdRegistry {
+	client := StatsdRegistry{prefix: prefix, addr: addr}
+	client.Open()
+	return &client
+}
+
+func (client *StatsdRegistry) Open() {
+	conn, err := net.Dial("udp", client.addr)
+	if err != nil {
+		log.Println(err)
+	}
+	client.conn = conn
+}
+
+func (client *StatsdRegistry) Close() {
+	client.conn.Close()
+}
+
+// Names is not supported by Statsd.
+func (client *StatsdRegistry) Names() []string { return nil }
+
+// Unregister is implicitly supported by Statsd,
+// stop submitting the metric and it stops being sent to Statsd.
+func (client *StatsdRegistry) Unregister(name string) {}
+
+// UnregisterAll is implicitly supported by Statsd,
+// stop submitting metrics and they will no longer be sent to Statsd.
+func (client *StatsdRegistry) UnregisterAll() {}
+
+// Arbitrarily updates a list of stats by a delta
+func (client *StatsdRegistry) UpdateStats(stats []string, delta int, sampleRate float32) {
+	statsToSend := make(map[string]string)
+	for _, stat := range stats {
+		updateString := fmt.Sprintf("%d|c", delta)
+		statsToSend[stat] = updateString
+	}
+	client.Send(statsToSend, sampleRate)
+}
+
+// Sends data to udp statsd daemon
+func (client *StatsdRegistry) Send(data map[string]string, sampleRate float32) {
+	sampledData := make(map[string]string)
+	if sampleRate < 1 {
+		r := rand.New(rand.NewSource(time.Now().Unix()))
+		rNum := r.Float32()
+		if rNum <= sampleRate {
+			for stat, value := range data {
+				sampledUpdateString := fmt.Sprintf("%s|@%f", value, sampleRate)
+				sampledData[stat] = sampledUpdateString
+			}
+		}
+	} else {
+		sampledData = data
+	}
+
+	for k, v := range sampledData {
+		updateString := fmt.Sprintf("%s:%s", k, v)
+		_, err := fmt.Fprintf(client.conn, updateString)
+		if err != nil {
+			log.Println(err)
+		}
+	}
+}
+
+func (client StatsdRegistry) GetCounter(name string) Counter {
+	return StatsdCounter{&client, client.prefix + name}
+}
+
+type StatsdCounter struct {
+	client *StatsdRegistry
+	name   string
+}
+
+func (c StatsdCounter) Inc(n int64) {
+	stats := []string{c.name}
+	c.client.UpdateStats(stats, int(n), 1)
+}
+
+func (client StatsdRegistry) GetTimer(name string) Timer {
+	return StatsdTimer{&client, client.prefix + name}
+}
+
+type StatsdTimer struct {
+	client *StatsdRegistry
+	name   string
+}
+
+func (t StatsdTimer) Update(n time.Duration) {
+	duration := int64(n / time.Millisecond)
+	updateString := fmt.Sprintf("%d|ms", duration)
+	stats := map[string]string{t.name: updateString}
+	t.client.Send(stats, 1)
+}
+
+func (t StatsdTimer) UpdateSince(then time.Time) {
+	duration := time.Since(then)
+	t.Update(duration)
+}
+
+// Percentile is not supported by Statsd.
+func (t StatsdTimer) Percentile(nth float64) float64 { return 0 }
+
+// Rate1 is not supported by Statsd.
+func (t StatsdTimer) Rate1() float64 { return 0 }


### PR DESCRIPTION
This is purely a proof of concept that demonstrates what is being discussed in #327 client code is cribbed directly from github.com/etsy/statsd/examples/go and could be further reduced and cleaned up.


* adds new metric sink `raw_statsd` uses same config as `statsd`
* new sink sends singl raw events directly to statsd server without any
  preaggreation or rollup.
* TODO - use more featureful/performant statsd client implementation such as
  https://github.com/alexcesaro/statsd or https://github.com/quipo/statsd
  which implement features such as optional buffering.