### PR TITLE
Issue #375: set host header when host option is set

### DIFF
--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -132,7 +132,7 @@ func TestProxyHost(t *testing.T) {
 		},
 		Lookup: func(r *http.Request) *route.Target {
 			routes := "route add mock /hostdst http://a.com/ opts \"host=dst\"\n"
-			routes += "route add mock /hostunknown http://a.com/ opts \"host=garbble\"\n"
+			routes += "route add mock /hostcustom http://a.com/ opts \"host=foo.com\"\n"
 			routes += "route add mock / http://a.com/"
 			tbl, _ := route.NewTable(routes)
 			return tbl.Lookup(r, "", route.Picker["rr"], route.Matcher["prefix"])
@@ -152,7 +152,7 @@ func TestProxyHost(t *testing.T) {
 
 	proxyHost := proxy.URL[len("http://"):]
 	t.Run("host eq dst", func(t *testing.T) { check(t, "/hostdst", "a.com") })
-	t.Run("host is unknown", func(t *testing.T) { check(t, "/hostunknown", proxyHost) })
+	t.Run("host is custom", func(t *testing.T) { check(t, "/hostcustom", "foo.com") })
 	t.Run("no host", func(t *testing.T) { check(t, "/", proxyHost) })
 }
 

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -89,6 +89,8 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if t.Host == "dst" {
 		r.Host = targetURL.Host
+	} else if t.Host != "" {
+		r.Host = t.Host
 	}
 
 	// TODO(fs): The HasPrefix check seems redundant since the lookup function should


### PR DESCRIPTION
This patch sets the Host header when the `host` option is set but not
`dst`.

Fixes #375