### PR TITLE
Issue #385: attach options to target instead of route

### DIFF
--- a/admin/api/routes.go
+++ b/admin/api/routes.go
@@ -43,12 +43,12 @@ func (h *RoutesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var routes []apiRoute
 	for _, host := range hosts {
 		for _, tr := range t[host] {
-			var opts []string
-			for k, v := range tr.Opts {
-				opts = append(opts, k+"="+v)
-			}
-
 			for _, tg := range tr.Targets {
+				var opts []string
+				for k, v := range tg.Opts {
+					opts = append(opts, k+"="+v)
+				}
+
 				ar := apiRoute{
 					Service: tg.Service,
 					Host:    tr.Host,

--- a/route/picker_test.go
+++ b/route/picker_test.go
@@ -21,8 +21,8 @@ func mustParse(rawurl string) *url.URL {
 
 func TestRndPicker(t *testing.T) {
 	r := &Route{Host: "www.bar.com", Path: "/foo"}
-	r.addTarget("svc", fooDotCom, 0, nil)
-	r.addTarget("svc", barDotCom, 0, nil)
+	r.addTarget("svc", fooDotCom, 0, nil, nil)
+	r.addTarget("svc", barDotCom, 0, nil, nil)
 
 	tests := []struct {
 		rnd       int
@@ -45,8 +45,8 @@ func TestRndPicker(t *testing.T) {
 
 func TestRRPicker(t *testing.T) {
 	r := &Route{Host: "www.bar.com", Path: "/foo"}
-	r.addTarget("svc", fooDotCom, 0, nil)
-	r.addTarget("svc", barDotCom, 0, nil)
+	r.addTarget("svc", fooDotCom, 0, nil, nil)
+	r.addTarget("svc", barDotCom, 0, nil, nil)
 
 	tests := []*url.URL{fooDotCom, barDotCom, fooDotCom, barDotCom, fooDotCom, barDotCom}
 

--- a/route/table.go
+++ b/route/table.go
@@ -153,20 +153,20 @@ func (t Table) addRoute(d *RouteDef) error {
 	switch {
 	// add new host
 	case t[host] == nil:
-		r := &Route{Host: host, Path: path, Opts: d.Opts}
-		r.addTarget(d.Service, targetURL, d.Weight, d.Tags)
+		r := &Route{Host: host, Path: path}
+		r.addTarget(d.Service, targetURL, d.Weight, d.Tags, d.Opts)
 		t[host] = Routes{r}
 
 	// add new route to existing host
 	case t[host].find(path) == nil:
-		r := &Route{Host: host, Path: path, Opts: d.Opts}
-		r.addTarget(d.Service, targetURL, d.Weight, d.Tags)
+		r := &Route{Host: host, Path: path}
+		r.addTarget(d.Service, targetURL, d.Weight, d.Tags, d.Opts)
 		t[host] = append(t[host], r)
 		sort.Sort(t[host])
 
 	// add new target to existing route
 	default:
-		t[host].find(path).addTarget(d.Service, targetURL, d.Weight, d.Tags)
+		t[host].find(path).addTarget(d.Service, targetURL, d.Weight, d.Tags, d.Opts)
 	}
 
 	return nil

--- a/route/table_test.go
+++ b/route/table_test.go
@@ -46,6 +46,28 @@ func TestTableParse(t *testing.T) {
 			},
 		},
 
+		{"1 service, 1 prefix with option",
+			[]string{
+				`route add svc-a / http://aaa.com/ opts "strip=/foo"`,
+				`route add svc-b / http://bbb.com/ opts "strip=/bar"`,
+			},
+			[]string{
+				`route add svc-a / http://aaa.com/ weight 0.5000 opts "strip=/foo"`,
+				`route add svc-b / http://bbb.com/ weight 0.5000 opts "strip=/bar"`,
+			},
+		},
+
+		{"1 service, 1 prefix, 2 instances with different options",
+			[]string{
+				`route add svc-a / http://aaa.com/ opts "strip=/foo"`,
+				`route add svc-b / http://bbb.com/ opts "strip=/bar"`,
+			},
+			[]string{
+				`route add svc-a / http://aaa.com/ weight 0.5000 opts "strip=/foo"`,
+				`route add svc-b / http://bbb.com/ weight 0.5000 opts "strip=/bar"`,
+			},
+		},
+
 		{"2 service, 1 prefix",
 			[]string{
 				`route add svc-a / http://aaa.com/`,

--- a/route/target.go
+++ b/route/target.go
@@ -13,6 +13,9 @@ type Target struct {
 	// Tags are the list of tags for this target
 	Tags []string
 
+	// Opts is the raw options for the target.
+	Opts map[string]string
+
 	// StripPath will be removed from the front of the outgoing
 	// request path
 	StripPath string


### PR DESCRIPTION
When defining a route for a given target the options were stored on the
Route object which had the effect that the first route definition
defined the route options for all instances. This was done under the
assumption that the options for a route would be the same for all
targets.

However, it should be possible to define different options for different
targets of the same route for example during a migration from one
service to another. This patch enables that behavior.

Fixes #385