### PR TITLE
Implement redirect capability

### DIFF
--- a/admin/api/routes.go
+++ b/admin/api/routes.go
@@ -62,6 +62,9 @@ func (h *RoutesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					Rate1:   tg.Timer.Rate1(),
 					Pct99:   tg.Timer.Percentile(0.99),
 				}
+				if tg.RedirectCode != 0 {
+					ar.Dst = fmt.Sprintf("%d|%s", tg.RedirectCode, tg.URL)
+				}
 				routes = append(routes, ar)
 			}
 		}

--- a/admin/api/routes.go
+++ b/admin/api/routes.go
@@ -62,9 +62,6 @@ func (h *RoutesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					Rate1:   tg.Timer.Rate1(),
 					Pct99:   tg.Timer.Percentile(0.99),
 				}
-				if tg.RedirectCode != 0 {
-					ar.Dst = fmt.Sprintf("%d|%s", tg.RedirectCode, tg.URL)
-				}
 				routes = append(routes, ar)
 			}
 		}

--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -178,9 +178,9 @@ func TestProxyHost(t *testing.T) {
 }
 
 func TestRedirect(t *testing.T) {
-	routes := "route add mock / http://a.com opts \"redirect=301\"\n"
+	routes := "route add mock / http://a.com/$path opts \"redirect=301\"\n"
 	routes += "route add mock /foo http://a.com/abc opts \"redirect=301\"\n"
-	routes += "route add mock /bar http://b.com opts \"redirect=302\"\n"
+	routes += "route add mock /bar http://b.com/$path opts \"redirect=302 strip=/bar\"\n"
 	tbl, _ := route.NewTable(routes)
 
 	proxy := httptest.NewServer(&HTTPProxy{
@@ -197,8 +197,10 @@ func TestRedirect(t *testing.T) {
 		wantLoc  string
 	}{
 		{req: "/", wantCode: 301, wantLoc: "http://a.com/"},
+		{req: "/aaa/bbb", wantCode: 301, wantLoc: "http://a.com/aaa/bbb"},
 		{req: "/foo", wantCode: 301, wantLoc: "http://a.com/abc"},
 		{req: "/bar", wantCode: 302, wantLoc: "http://b.com"},
+		{req: "/bar/aaa", wantCode: 302, wantLoc: "http://b.com/aaa"},
 	}
 
 	http.DefaultClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {

--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -178,8 +178,9 @@ func TestProxyHost(t *testing.T) {
 }
 
 func TestRedirect(t *testing.T) {
-	routes := "route add mock /foo http://a.com/abc opts \"redirect=301\"\n"
-	routes += "route add mock /bar http://b.com/ opts \"redirect=302\"\n"
+	routes := "route add mock / http://a.com opts \"redirect=301\"\n"
+	routes += "route add mock /foo http://a.com/abc opts \"redirect=301\"\n"
+	routes += "route add mock /bar http://b.com opts \"redirect=302\"\n"
 	tbl, _ := route.NewTable(routes)
 
 	proxy := httptest.NewServer(&HTTPProxy{
@@ -195,6 +196,7 @@ func TestRedirect(t *testing.T) {
 		wantCode int
 		wantLoc  string
 	}{
+		{req: "/", wantCode: 301, wantLoc: "http://a.com/"},
 		{req: "/foo", wantCode: 301, wantLoc: "http://a.com/abc"},
 		{req: "/bar", wantCode: 302, wantLoc: "http://b.com"},
 	}

--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -177,6 +177,45 @@ func TestProxyHost(t *testing.T) {
 	})
 }
 
+func TestRedirect(t *testing.T) {
+	routes := "route add mock /foo http://a.com/abc opts \"redirect=301\"\n"
+	routes += "route add mock /bar http://b.com/ opts \"redirect=302\"\n"
+	tbl, _ := route.NewTable(routes)
+
+	proxy := httptest.NewServer(&HTTPProxy{
+		Transport: http.DefaultTransport,
+		Lookup: func(r *http.Request) *route.Target {
+			return tbl.Lookup(r, "", route.Picker["rr"], route.Matcher["prefix"])
+		},
+	})
+	defer proxy.Close()
+
+	tests := []struct {
+		req      string
+		wantCode int
+		wantLoc  string
+	}{
+		{req: "/foo", wantCode: 301, wantLoc: "http://a.com/abc"},
+		{req: "/bar", wantCode: 302, wantLoc: "http://b.com"},
+	}
+
+	http.DefaultClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// do not follow redirects
+		return http.ErrUseLastResponse
+	}
+
+	for _, tt := range tests {
+		resp, _ := mustGet(proxy.URL + tt.req)
+		if resp.StatusCode != tt.wantCode {
+			t.Errorf("got status code %d, want %d", resp.StatusCode, tt.wantCode)
+		}
+		gotLoc, _ := resp.Location()
+		if gotLoc.String() != tt.wantLoc {
+			t.Errorf("got location %s, want %s", gotLoc, tt.wantLoc)
+		}
+	}
+}
+
 func TestProxyLogOutput(t *testing.T) {
 	// build a format string from all log fields and one header field
 	fields := []string{"header.X-Foo:$header.X-Foo"}

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -114,6 +114,15 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set(p.Config.RequestID, id())
 	}
 
+	if t.RedirectCode != 0 {
+		http.Redirect(w, r, targetURL.String(), t.RedirectCode)
+		if t.Timer != nil {
+			t.Timer.Update(0)
+		}
+		metrics.DefaultRegistry.GetTimer(key(t.RedirectCode)).Update(0)
+		return
+	}
+
 	upgrade, accept := r.Header.Get("Upgrade"), r.Header.Get("Accept")
 
 	tr := p.Transport

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -60,6 +60,14 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		panic("no lookup function")
 	}
 
+	if p.Config.RequestID != "" {
+		id := p.UUID
+		if id == nil {
+			id = uuid.NewUUID
+		}
+		r.Header.Set(p.Config.RequestID, id())
+	}
+
 	t := p.Lookup(r)
 	if t == nil {
 		w.WriteHeader(p.Config.NoRouteStatus)
@@ -73,6 +81,16 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Host:     r.Host,
 		Path:     r.URL.Path,
 		RawQuery: r.URL.RawQuery,
+	}
+
+	if t.RedirectCode != 0 {
+		redirectURL := t.GetRedirectURL(requestURL)
+		http.Redirect(w, r, redirectURL.String(), t.RedirectCode)
+		if t.Timer != nil {
+			t.Timer.Update(0)
+		}
+		metrics.DefaultRegistry.GetTimer(key(t.RedirectCode)).Update(0)
+		return
 	}
 
 	// build the real target url that is passed to the proxy
@@ -103,23 +121,6 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if err := addHeaders(r, p.Config, t.StripPath); err != nil {
 		http.Error(w, "cannot parse "+r.RemoteAddr, http.StatusInternalServerError)
-		return
-	}
-
-	if p.Config.RequestID != "" {
-		id := p.UUID
-		if id == nil {
-			id = uuid.NewUUID
-		}
-		r.Header.Set(p.Config.RequestID, id())
-	}
-
-	if t.RedirectCode != 0 {
-		http.Redirect(w, r, targetURL.String(), t.RedirectCode)
-		if t.Timer != nil {
-			t.Timer.Update(0)
-		}
-		metrics.DefaultRegistry.GetTimer(key(t.RedirectCode)).Update(0)
 		return
 	}
 

--- a/registry/consul/parse_test.go
+++ b/registry/consul/parse_test.go
@@ -47,6 +47,12 @@ func TestParseTag(t *testing.T) {
 			route: "xx/Yy",
 			ok:    true,
 		},
+		{
+			tag:   "p-www.bar.com:80/foo https://www.bar.com/ redirect=302",
+			route: "www.bar.com:80/foo",
+			opts:  "https://www.bar.com/ redirect=302",
+			ok:    true,
+		},
 	}
 
 	for i, tt := range tests {

--- a/registry/consul/parse_test.go
+++ b/registry/consul/parse_test.go
@@ -48,9 +48,9 @@ func TestParseTag(t *testing.T) {
 			ok:    true,
 		},
 		{
-			tag:   "p-www.bar.com:80/foo https://www.bar.com/ redirect=302",
+			tag:   "p-www.bar.com:80/foo redirect=302,https://www.bar.com",
 			route: "www.bar.com:80/foo",
-			opts:  "https://www.bar.com/ redirect=302",
+			opts:  "redirect=302,https://www.bar.com",
 			ok:    true,
 		},
 	}

--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"runtime"
@@ -119,14 +120,21 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 				dst := "http://" + addr + "/"
 				for _, o := range strings.Fields(opts) {
 					switch {
-					case strings.Contains(o, "://"):
-						dst = o
 					case o == "proto=tcp":
 						dst = "tcp://" + addr
 					case o == "proto=https":
 						dst = "https://" + addr
 					case strings.HasPrefix(o, "weight="):
 						weight = o[len("weight="):]
+					case strings.HasPrefix(o, "redirect="):
+						redir := strings.Split(o[len("redirect="):], ",")
+						if len(redir) == 2 {
+							dst = redir[1]
+							ropts = append(ropts, fmt.Sprintf("redirect=%s", redir[0]))
+						} else {
+							log.Printf("[ERROR] Invalid syntax for redirect: %s. should be redirect=<code>,<url>", o)
+							continue
+						}
 					default:
 						ropts = append(ropts, o)
 					}

--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -119,6 +119,8 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 				dst := "http://" + addr + "/"
 				for _, o := range strings.Fields(opts) {
 					switch {
+					case strings.Contains(o, "://"):
+						dst = o
 					case o == "proto=tcp":
 						dst = "tcp://" + addr
 					case o == "proto=https":

--- a/route/route.go
+++ b/route/route.go
@@ -76,7 +76,7 @@ func (r *Route) addTarget(service string, targetURL *url.URL, fixedWeight float6
 				log.Printf("[ERROR] redirect status code should be numeric in 3xx range. Got: %s", opts["redirect"])
 			} else if t.RedirectCode < 300 || t.RedirectCode > 399 {
 				t.RedirectCode = 0
-				log.Printf("[ERROR] redirect status code should in 3xx range. Got: %s", opts["redirect"])
+				log.Printf("[ERROR] redirect status code should be in 3xx range. Got: %s", opts["redirect"])
 			}
 		}
 	}

--- a/route/route.go
+++ b/route/route.go
@@ -70,6 +70,9 @@ func (r *Route) addTarget(service string, targetURL *url.URL, fixedWeight float6
 		t.TLSSkipVerify = opts["tlsskipverify"] == "true"
 		t.Host = opts["host"]
 		t.RedirectCode, _ = strconv.Atoi(opts["redirect"])
+		if t.RedirectCode < 300 || t.RedirectCode > 399 {
+			t.RedirectCode = 0
+		}
 	}
 
 	r.Targets = append(r.Targets, t)

--- a/route/table.go
+++ b/route/table.go
@@ -273,12 +273,12 @@ func (t Table) route(host, path string) *Route {
 
 // normalizeHost returns the hostname from the request
 // and removes the default port if present.
-func normalizeHost(host string, req *http.Request) string {
+func normalizeHost(host string, tls bool) string {
 	host = strings.ToLower(host)
-	if req.TLS == nil && strings.HasSuffix(host, ":80") {
+	if !tls && strings.HasSuffix(host, ":80") {
 		return host[:len(host)-len(":80")]
 	}
-	if req.TLS != nil && strings.HasSuffix(host, ":443") {
+	if tls && strings.HasSuffix(host, ":443") {
 		return host[:len(host)-len(":443")]
 	}
 	return host
@@ -287,9 +287,9 @@ func normalizeHost(host string, req *http.Request) string {
 // matchingHosts returns all keys (host name patterns) from the
 // routing table which match the normalized request hostname.
 func (t Table) matchingHosts(req *http.Request) (hosts []string) {
-	host := normalizeHost(req.Host, req)
+	host := normalizeHost(req.Host, req.TLS != nil)
 	for pattern := range t {
-		normpat := normalizeHost(pattern, req)
+		normpat := normalizeHost(pattern, req.TLS != nil)
 		if glob.Glob(normpat, host) {
 			hosts = append(hosts, pattern)
 		}

--- a/route/table.go
+++ b/route/table.go
@@ -273,8 +273,8 @@ func (t Table) route(host, path string) *Route {
 
 // normalizeHost returns the hostname from the request
 // and removes the default port if present.
-func normalizeHost(req *http.Request) string {
-	host := strings.ToLower(req.Host)
+func normalizeHost(host string, req *http.Request) string {
+	host = strings.ToLower(host)
 	if req.TLS == nil && strings.HasSuffix(host, ":80") {
 		return host[:len(host)-len(":80")]
 	}
@@ -287,9 +287,10 @@ func normalizeHost(req *http.Request) string {
 // matchingHosts returns all keys (host name patterns) from the
 // routing table which match the normalized request hostname.
 func (t Table) matchingHosts(req *http.Request) (hosts []string) {
-	host := normalizeHost(req)
+	host := normalizeHost(req.Host, req)
 	for pattern := range t {
-		if glob.Glob(pattern, host) {
+		normpat := normalizeHost(pattern, req)
+		if glob.Glob(normpat, host) {
 			hosts = append(hosts, pattern)
 		}
 	}

--- a/route/table_test.go
+++ b/route/table_test.go
@@ -416,6 +416,9 @@ func TestTableParse(t *testing.T) {
 				targetURLs := make([]string, len(r.wTargets))
 				for i, tg := range r.wTargets {
 					targetURLs[i] = tg.URL.Scheme + "://" + tg.URL.Host + tg.URL.Path
+					if tg.RedirectCode != 0 {
+						targetURLs[i] = fmt.Sprintf("%d|%s", tg.RedirectCode, targetURLs[i])
+					}
 				}
 
 				// count how often the 'url' from 'route add svc <path> <url>'
@@ -477,7 +480,7 @@ func TestNormalizeHost(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		if got, want := normalizeHost(tt.req), tt.host; got != want {
+		if got, want := normalizeHost(tt.req.Host, tt.req), tt.host; got != want {
 			t.Errorf("%d: got %v want %v", i, got, want)
 		}
 	}
@@ -495,6 +498,7 @@ func TestTableLookup(t *testing.T) {
 	route add svc z.abc.com/foo/ http://foo.com:3100
 	route add svc *.abc.com/ http://foo.com:4000
 	route add svc *.abc.com/foo/ http://foo.com:5000
+	route add svc xyz.com:80/ https://xyz.com
 	`
 
 	tbl, err := NewTable(s)
@@ -539,6 +543,9 @@ func TestTableLookup(t *testing.T) {
 
 		// exact match has precedence over glob match
 		{&http.Request{Host: "z.abc.com", URL: mustParse("/foo/")}, "http://foo.com:3100"},
+
+		// explicit port on route
+		{&http.Request{Host: "xyz.com", URL: mustParse("/")}, "https://xyz.com"},
 	}
 
 	for i, tt := range tests {

--- a/route/table_test.go
+++ b/route/table_test.go
@@ -416,9 +416,6 @@ func TestTableParse(t *testing.T) {
 				targetURLs := make([]string, len(r.wTargets))
 				for i, tg := range r.wTargets {
 					targetURLs[i] = tg.URL.Scheme + "://" + tg.URL.Host + tg.URL.Path
-					if tg.RedirectCode != 0 {
-						targetURLs[i] = fmt.Sprintf("%d|%s", tg.RedirectCode, targetURLs[i])
-					}
 				}
 
 				// count how often the 'url' from 'route add svc <path> <url>'

--- a/route/table_test.go
+++ b/route/table_test.go
@@ -477,7 +477,7 @@ func TestNormalizeHost(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		if got, want := normalizeHost(tt.req.Host, tt.req), tt.host; got != want {
+		if got, want := normalizeHost(tt.req.Host, tt.req.TLS != nil), tt.host; got != want {
 			t.Errorf("%d: got %v want %v", i, got, want)
 		}
 	}

--- a/route/target.go
+++ b/route/target.go
@@ -33,6 +33,9 @@ type Target struct {
 	// URL is the endpoint the service instance listens on
 	URL *url.URL
 
+	// RedirectCode is the HTTP status code used for redirects.
+	RedirectCode int
+
 	// FixedWeight is the weight assigned to this target.
 	// If the value is 0 the targets weight is dynamic.
 	FixedWeight float64

--- a/route/target.go
+++ b/route/target.go
@@ -34,6 +34,7 @@ type Target struct {
 	URL *url.URL
 
 	// RedirectCode is the HTTP status code used for redirects.
+	// When set to a value > 0 the client is redirected to the target url.
 	RedirectCode int
 
 	// FixedWeight is the weight assigned to this target.

--- a/route/target_test.go
+++ b/route/target_test.go
@@ -1,0 +1,104 @@
+package route
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestTarget_GetRedirectURL(t *testing.T) {
+	type routeTest struct {
+		req  string
+		want string
+	}
+	tests := []struct {
+		route string
+		tests []routeTest
+	}{
+		{ // simple absolute redirect
+			route: "route add svc / http://bar.com/",
+			tests: []routeTest{
+				{req: "/", want: "http://bar.com/"},
+				{req: "/abc", want: "http://bar.com/"},
+				{req: "/a/b/c", want: "http://bar.com/"},
+				{req: "/?aaa=1", want: "http://bar.com/"},
+			},
+		},
+		{ // absolute redirect to deep path with query
+			route: "route add svc / http://bar.com/a/b/c?foo=bar",
+			tests: []routeTest{
+				{req: "/", want: "http://bar.com/a/b/c?foo=bar"},
+				{req: "/abc", want: "http://bar.com/a/b/c?foo=bar"},
+				{req: "/a/b/c", want: "http://bar.com/a/b/c?foo=bar"},
+				{req: "/?aaa=1", want: "http://bar.com/a/b/c?foo=bar"},
+			},
+		},
+		{ // simple redirect to corresponding path
+			route: "route add svc / http://bar.com/$path",
+			tests: []routeTest{
+				{req: "/", want: "http://bar.com/"},
+				{req: "/abc", want: "http://bar.com/abc"},
+				{req: "/a/b/c", want: "http://bar.com/a/b/c"},
+				{req: "/?aaa=1", want: "http://bar.com/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
+			},
+		},
+		{ // same as above but without / before $path
+			route: "route add svc / http://bar.com$path",
+			tests: []routeTest{
+				{req: "/", want: "http://bar.com/"},
+				{req: "/abc", want: "http://bar.com/abc"},
+				{req: "/a/b/c", want: "http://bar.com/a/b/c"},
+				{req: "/?aaa=1", want: "http://bar.com/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
+			},
+		},
+		{ // arbitrary subdir on target with $path at end
+			route: "route add svc / http://bar.com/bbb/$path",
+			tests: []routeTest{
+				{req: "/", want: "http://bar.com/bbb/"},
+				{req: "/abc", want: "http://bar.com/bbb/abc"},
+				{req: "/a/b/c", want: "http://bar.com/bbb/a/b/c"},
+				{req: "/?aaa=1", want: "http://bar.com/bbb/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "http://bar.com/bbb/abc/?aaa=1"},
+			},
+		},
+		{ // same as above but without / before $path
+			route: "route add svc / http://bar.com/bbb$path",
+			tests: []routeTest{
+				{req: "/", want: "http://bar.com/bbb/"},
+				{req: "/abc", want: "http://bar.com/bbb/abc"},
+				{req: "/a/b/c", want: "http://bar.com/bbb/a/b/c"},
+				{req: "/?aaa=1", want: "http://bar.com/bbb/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "http://bar.com/bbb/abc/?aaa=1"},
+			},
+		},
+		{ // strip prefix
+			route: "route add svc /stripme http://bar.com/$path opts \"strip=/stripme\"",
+			tests: []routeTest{
+				{req: "/stripme/", want: "http://bar.com/"},
+				{req: "/stripme/abc", want: "http://bar.com/abc"},
+				{req: "/stripme/a/b/c", want: "http://bar.com/a/b/c"},
+				{req: "/stripme/?aaa=1", want: "http://bar.com/?aaa=1"},
+				{req: "/stripme/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
+			},
+		},
+	}
+	firstRoute := func(tbl Table) *Route {
+		for _, routes := range tbl {
+			return routes[0]
+		}
+		return nil
+	}
+	for _, tt := range tests {
+		tbl, _ := NewTable(tt.route)
+		route := firstRoute(tbl)
+		target := route.Targets[0]
+		for _, rt := range tt.tests {
+			reqURL, _ := url.Parse("http://foo.com" + rt.req)
+			got := target.GetRedirectURL(reqURL)
+			if got.String() != rt.want {
+				t.Errorf("Got %s, wanted %s", got, rt.want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
NOTE: The syntax described below was not used in the final implementation.

This is my initial attempt to implement the ability to perform redirections (see #87). I decided to indicate a redirect by prefixing the destination with the HTTP status code to be used for redirection, followed by a pipe, followed by the specific URL you want to redirect to. There is no built-in protection against creating redirect loops currently. Here is how you might use it:

```
route add svc example.com:80/ 302|https://example.com
route add svc example.com:443/ 1.2.3.4:5678
```
Note that these include explicit source ports. To use it on consul services, you have to use multiple service tags.
```
urlprefix-example.com:80/ 302|https://example.com
urlprefix-example.com:443/
```
You can create redirect routes to anywhere.
```
route add svc example.com/dothething/ 301|https://github.com/fabiolb/fabio
```

Looking for feedback.
(Signed CLA)