### PR TITLE
Actually respect -version option

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -59,7 +59,7 @@ func parse(args []string) (cmdline []string, path string, version bool, err erro
 
 		switch {
 		// version flag
-		case arg == "-v" || arg == "--version":
+		case arg == "-v" || arg == "-version" || arg == "--version":
 			return nil, "", true, nil
 
 		// config file without '='


### PR DESCRIPTION
```
$ ./fabio -help 2>&1 | tail -3
  -v    Show version
  -version
        Show version
```

-version didn't actually work (-v and --version did); fabio would just start normally.
