### PR TITLE
Issue #408: log consul state changes as DEBUG

### DIFF
--- a/cert/consul_source.go
+++ b/cert/consul_source.go
@@ -120,7 +120,7 @@ func watchKV(client *api.Client, key string, pemBlocks chan map[string][]byte) {
 		}
 
 		if !reflect.DeepEqual(value, lastValue) || index != lastIndex {
-			log.Printf("[INFO] cert: Certificate index changed to #%d", index)
+			log.Printf("[DEBUG] cert: Certificate index changed to #%d", index)
 			pemBlocks <- value
 			lastValue, lastIndex = value, index
 		}

--- a/registry/consul/kv.go
+++ b/registry/consul/kv.go
@@ -23,7 +23,7 @@ func watchKV(client *api.Client, path string, config chan string) {
 		}
 
 		if value != lastValue || index != lastIndex {
-			log.Printf("[INFO] consul: Manual config changed to #%d", index)
+			log.Printf("[DEBUG] consul: Manual config changed to #%d", index)
 			config <- value
 			lastValue, lastIndex = value, index
 		}

--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -27,7 +27,7 @@ func watchServices(client *api.Client, tagPrefix string, status []string, config
 			continue
 		}
 
-		log.Printf("[INFO] consul: Health changed to #%d", meta.LastIndex)
+		log.Printf("[DEBUG] consul: Health changed to #%d", meta.LastIndex)
 		config <- servicesConfig(client, passingServices(checks, status), tagPrefix)
 		lastIndex = meta.LastIndex
 	}


### PR DESCRIPTION
This patch changes the log level for Consul raft log changes from
INFO to DEBUG so that most users will not see this anymore. High
change rate is usually an indicator for flapping services or health
checks with volatile output like timestamps but that problem should be
dealt with on the Consul side.

A PR for #368 will to add an indicator for the change rate of the Consul
state.

Fixes #408