### PR TITLE
Check if XFF is available before denying on IP

### DIFF
--- a/route/access_rules.go
+++ b/route/access_rules.go
@@ -29,11 +29,6 @@ func (t *Target) AccessDeniedHTTP(r *http.Request) bool {
 		log.Printf("[WARN] failed to parse remote address %s", host)
 	}
 
-	// check remote source and return if denied
-	if t.denyByIP(ip) {
-		return true
-	}
-
 	// check xff source if present
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		// only use left-most element (client)
@@ -48,6 +43,11 @@ func (t *Target) AccessDeniedHTTP(r *http.Request) bool {
 				return true
 			}
 		}
+	}
+
+	// check remote source and return if denied
+	if t.denyByIP(ip) {
+		return true
 	}
 
 	// default allow


### PR DESCRIPTION
When using allow=ip:x.x.x.x behind an application loadbalancer Fabio will always deny access since it does the denyByIP before checking if there is a "X-Forwarded-For" available and therefore uses the loadbalancers ip as source, this PR puts the denyByIP after the XFF check and makes it work as intended.