### PR TITLE
Catch all redirect

### DIFF
--- a/route/target.go
+++ b/route/target.go
@@ -78,5 +78,8 @@ func (t *Target) GetRedirectURL(requestURL *url.URL) *url.URL {
 			redirectURL.RawQuery = requestURL.RawQuery
 		}
 	}
+	if strings.Contains(redirectURL.Host, "$host") {
+		redirectURL.Host = strings.Replace(redirectURL.Host, "$host", requestURL.Host, 1)
+	}
 	return redirectURL
 }

--- a/route/target_test.go
+++ b/route/target_test.go
@@ -26,6 +26,16 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 			},
 		},
 		{
+			desc:  "simple catch-all redirect",
+			route: "route add svc / http://$host/",
+			tests: []routeTest{
+				{req: "/", want: "http://foo.com/"},
+				{req: "/abc", want: "http://foo.com/"},
+				{req: "/a/b/c", want: "http://foo.com/"},
+				{req: "/?aaa=1", want: "http://foo.com/"},
+			},
+		},
+		{
 			desc:  "absolute redirect to deep path with query",
 			route: "route add svc / http://bar.com/a/b/c?foo=bar",
 			tests: []routeTest{
@@ -33,6 +43,16 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/abc", want: "http://bar.com/a/b/c?foo=bar"},
 				{req: "/a/b/c", want: "http://bar.com/a/b/c?foo=bar"},
 				{req: "/?aaa=1", want: "http://bar.com/a/b/c?foo=bar"},
+			},
+		},
+		{
+			desc:  "catch-all redirect to deep path with query",
+			route: "route add svc / http://$host/a/b/c?foo=bar",
+			tests: []routeTest{
+				{req: "/", want: "http://foo.com/a/b/c?foo=bar"},
+				{req: "/abc", want: "http://foo.com/a/b/c?foo=bar"},
+				{req: "/a/b/c", want: "http://foo.com/a/b/c?foo=bar"},
+				{req: "/?aaa=1", want: "http://foo.com/a/b/c?foo=bar"},
 			},
 		},
 		{
@@ -44,6 +64,28 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/a/b/c", want: "http://bar.com/a/b/c"},
 				{req: "/?aaa=1", want: "http://bar.com/?aaa=1"},
 				{req: "/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
+			},
+		},
+		{
+			desc:  "catch-all redirect to corresponding path",
+			route: "route add svc / http://$host/$path",
+			tests: []routeTest{
+				{req: "/", want: "http://foo.com/"},
+				{req: "/abc", want: "http://foo.com/abc"},
+				{req: "/a/b/c", want: "http://foo.com/a/b/c"},
+				{req: "/?aaa=1", want: "http://foo.com/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "http://foo.com/abc/?aaa=1"},
+			},
+		},
+		{
+			desc:  "catch-all http to https",
+			route: "route add svc / https://$host/$path",
+			tests: []routeTest{
+				{req: "/", want: "https://foo.com/"},
+				{req: "/abc", want: "https://foo.com/abc"},
+				{req: "/a/b/c", want: "https://foo.com/a/b/c"},
+				{req: "/?aaa=1", want: "https://foo.com/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "https://foo.com/abc/?aaa=1"},
 			},
 		},
 		{
@@ -88,6 +130,17 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/stripme/a/b/c", want: "http://bar.com/a/b/c"},
 				{req: "/stripme/?aaa=1", want: "http://bar.com/?aaa=1"},
 				{req: "/stripme/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
+			},
+		},
+		{
+			desc:  "catch-all with strip prefix",
+			route: "route add svc /stripme http://$host/$path opts \"strip=/stripme\"",
+			tests: []routeTest{
+				{req: "/stripme/", want: "http://foo.com/"},
+				{req: "/stripme/abc", want: "http://foo.com/abc"},
+				{req: "/stripme/a/b/c", want: "http://foo.com/a/b/c"},
+				{req: "/stripme/?aaa=1", want: "http://foo.com/?aaa=1"},
+				{req: "/stripme/abc/?aaa=1", want: "http://foo.com/abc/?aaa=1"},
 			},
 		},
 	}

--- a/route/target_test.go
+++ b/route/target_test.go
@@ -11,10 +11,12 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 		want string
 	}
 	tests := []struct {
+		desc  string
 		route string
 		tests []routeTest
 	}{
-		{ // simple absolute redirect
+		{
+			desc:  "simple absolute redirect",
 			route: "route add svc / http://bar.com/",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/"},
@@ -23,7 +25,8 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/?aaa=1", want: "http://bar.com/"},
 			},
 		},
-		{ // absolute redirect to deep path with query
+		{
+			desc:  "absolute redirect to deep path with query",
 			route: "route add svc / http://bar.com/a/b/c?foo=bar",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/a/b/c?foo=bar"},
@@ -32,7 +35,8 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/?aaa=1", want: "http://bar.com/a/b/c?foo=bar"},
 			},
 		},
-		{ // simple redirect to corresponding path
+		{
+			desc:  "simple redirect to corresponding path",
 			route: "route add svc / http://bar.com/$path",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/"},
@@ -42,7 +46,8 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
 			},
 		},
-		{ // same as above but without / before $path
+		{
+			desc:  "same as above but without / before $path",
 			route: "route add svc / http://bar.com$path",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/"},
@@ -52,7 +57,8 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
 			},
 		},
-		{ // arbitrary subdir on target with $path at end
+		{
+			desc:  "arbitrary subdir on target with $path at end",
 			route: "route add svc / http://bar.com/bbb/$path",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/bbb/"},
@@ -62,7 +68,8 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/abc/?aaa=1", want: "http://bar.com/bbb/abc/?aaa=1"},
 			},
 		},
-		{ // same as above but without / before $path
+		{
+			desc:  "same as above but without / before $path",
 			route: "route add svc / http://bar.com/bbb$path",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/bbb/"},
@@ -72,7 +79,8 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 				{req: "/abc/?aaa=1", want: "http://bar.com/bbb/abc/?aaa=1"},
 			},
 		},
-		{ // strip prefix
+		{
+			desc:  "strip prefix",
 			route: "route add svc /stripme http://bar.com/$path opts \"strip=/stripme\"",
 			tests: []routeTest{
 				{req: "/stripme/", want: "http://bar.com/"},
@@ -90,15 +98,19 @@ func TestTarget_GetRedirectURL(t *testing.T) {
 		return nil
 	}
 	for _, tt := range tests {
-		tbl, _ := NewTable(tt.route)
-		route := firstRoute(tbl)
-		target := route.Targets[0]
-		for _, rt := range tt.tests {
-			reqURL, _ := url.Parse("http://foo.com" + rt.req)
-			got := target.GetRedirectURL(reqURL)
-			if got.String() != rt.want {
-				t.Errorf("Got %s, wanted %s", got, rt.want)
+		t.Run(tt.desc, func(t *testing.T) {
+			tbl, _ := NewTable(tt.route)
+			route := firstRoute(tbl)
+			target := route.Targets[0]
+			for _, rt := range tt.tests {
+				t.Run("", func(t *testing.T) {
+					reqURL, _ := url.Parse("http://foo.com" + rt.req)
+					got := target.GetRedirectURL(reqURL)
+					if got.String() != rt.want {
+						t.Errorf("Got %s, wanted %s", got, rt.want)
+					}
+				})
 			}
-		}
+		})
 	}
 }


### PR DESCRIPTION
This patch adds the option to redirect to the same host but maybe on a different path or scheme.

For this `$host` can be used on the target URL, e.g.

```
route add https-redirect / https://$host$path opts "redirect=301"
```