### PR TITLE
Fix the regex of the example proxy.gzip.contenttype

### DIFF
--- a/config/load_test.go
+++ b/config/load_test.go
@@ -426,6 +426,13 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			args: []string{"-proxy.gzip.contenttype", "^(text/.*|application/(javascript|json|font-woff|xml)|.*\\+(json|xml))(;.*)?$"},
+			cfg: func(cfg *Config) *Config {
+				cfg.Proxy.GZIPContentTypes = regexp.MustCompile(`^(text/.*|application/(javascript|json|font-woff|xml)|.*\+(json|xml))(;.*)?$`)
+				return cfg
+			},
+		},
+		{
 			args: []string{"-proxy.log.routes", "foobar"},
 			cfg: func(cfg *Config) *Config {
 				cfg.Log.RoutesFormat = "foobar"

--- a/fabio.properties
+++ b/fabio.properties
@@ -441,7 +441,7 @@
 #
 # A typical example is
 #
-# proxy.gzip.contenttype = ^(text/.*|application/(javascript|json|font-woff|xml)|.*\+(json|xml))(;.*)?$
+# proxy.gzip.contenttype = ^(text/.*|application/(javascript|json|font-woff|xml)|.*\\+(json|xml))(;.*)?$
 #
 # The default is
 #


### PR DESCRIPTION
The backslash wasn't properly escaped, making fabio not wanting to start when uncommenting the example in `fabio.properties`