### PR TITLE
Issue #460: Fix access logging when gzip is enabled

### DIFF
--- a/proxy/http_handler.go
+++ b/proxy/http_handler.go
@@ -24,20 +24,6 @@ func newHTTPProxy(target *url.URL, tr http.RoundTripper, flush time.Duration) ht
 			}
 		},
 		FlushInterval: flush,
-		Transport:     &transport{tr, nil, nil},
+		Transport:     tr,
 	}
-}
-
-// transport executes the roundtrip and captures the response. It is not
-// safe for multiple or concurrent use since it only captures a single
-// response.
-type transport struct {
-	http.RoundTripper
-	resp *http.Response
-	err  error
-}
-
-func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
-	t.resp, t.err = t.RoundTripper.RoundTrip(r)
-	return t.resp, t.err
 }


### PR DESCRIPTION
The code that captured the content length and the status code
for the access logger depended on the http.Handler to be of a
certain type. Wrapping the handler in a gzip handler broke this
silently.

This fix removes that dependency and instead wraps the response
writer directly to capture the values required for access logging.

Fixes #460 
Closes #469 