### PR TITLE
ws close on failed handshake (#421)

### DIFF
--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -162,7 +162,6 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			h = newRawProxy(targetURL.Host, net.Dial)
 		}
-		r.Header.Set("Connection", "close")
 
 	case accept == "text/event-stream":
 		// use the flush interval for SSE (server-sent events)

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -162,6 +162,7 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			h = newRawProxy(targetURL.Host, net.Dial)
 		}
+		r.Header.Set("Connection", "close")
 
 	case accept == "text/event-stream":
 		// use the flush interval for SSE (server-sent events)

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -156,11 +156,11 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case upgrade == "websocket" || upgrade == "Websocket":
 		r.URL = targetURL
 		if targetURL.Scheme == "https" || targetURL.Scheme == "wss" {
-			h = newRawProxy(targetURL.Host, func(network, address string) (net.Conn, error) {
+			h = newWSHandler(targetURL.Host, func(network, address string) (net.Conn, error) {
 				return tls.Dial(network, address, tr.(*http.Transport).TLSClientConfig)
 			})
 		} else {
-			h = newRawProxy(targetURL.Host, net.Dial)
+			h = newWSHandler(targetURL.Host, net.Dial)
 		}
 
 	case accept == "text/event-stream":

--- a/proxy/http_raw_handler.go
+++ b/proxy/http_raw_handler.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"log"
 	"net"
@@ -78,7 +77,6 @@ func newRawProxy(host string, dial dialFunc) http.Handler {
 		}
 
 		if !bytes.HasPrefix(b, []byte("HTTP/1.1 101")) {
-			fmt.Println("boom")
 			log.Printf("[INFO] WS Upgrade failed for %s", r.URL)
 			http.Error(w, "error handling ws upgrade", http.StatusInternalServerError)
 			return

--- a/proxy/ws_handler.go
+++ b/proxy/ws_handler.go
@@ -16,10 +16,11 @@ var conn = metrics.DefaultRegistry.GetCounter("ws.conn")
 
 type dialFunc func(network, address string) (net.Conn, error)
 
-// newRawProxy returns an HTTP handler which forwards data between
-// an incoming and outgoing TCP connection including the original request.
-// This handler establishes a new outgoing connection per request.
-func newRawProxy(host string, dial dialFunc) http.Handler {
+// newWSHandler returns an HTTP handler which forwards data between
+// an incoming and outgoing Websocket connection. It checks whether
+// the handshake was completed successfully before forwarding data
+// between the client and server.
+func newWSHandler(host string, dial dialFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn.Inc(1)
 		defer func() { conn.Inc(-1) }()


### PR DESCRIPTION
Close the websocket connection if the handshake failed.

Fixes #421 