### PR TITLE
Delete an unused global variable logOutput

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,8 +47,6 @@ var version = "1.5.9"
 
 var shuttingDown int32
 
-var logOutput logger.LevelWriter
-
 func main() {
 	logOutput := logger.NewLevelWriter(os.Stderr, "INFO", "2017/01/01 00:00:00 ")
 	log.SetOutput(logOutput)


### PR DESCRIPTION
logOutput is not used as a global variable, it is re-initialized as short-term variable in func main().