### PR TITLE
Fix changelog link in docs footer

### DIFF
--- a/docs/layouts/partials/footer.html
+++ b/docs/layouts/partials/footer.html
@@ -13,7 +13,7 @@
           </div>
           <div class="col-md-6 col-sm-6">
             <ul class="footer-menu">
-              <li><a href="https://github.com/fabiolb/website/commits/master">Changelog</a></li>
+              <li><a href="https://github.com/fabiolb/fabio/commits/master">Changelog</a></li>
               <li><a href="/contact/">Contact</a></li>
               <li>
                 <a href="https://gohugo.io"><img src="/img/made-with-hugo.png" height="51px"></a>


### PR DESCRIPTION
You can also consider changing the link to [CHANGELOG.md](https://github.com/fabiolb/fabio/blob/master/CHANGELOG.md).