### PR TITLE
[Docs] Delete duplicate 'Path Stripping' page

### DIFF
--- a/docs/content/feature/path-stripping.md
+++ b/docs/content/feature/path-stripping.md
@@ -1,9 +1,0 @@
----
-title: "Path Stripping"
-since: "1.3.7"
----
-
-fabio supports stripping a path from the incoming request. If you want to
-forward `http://host/foo/bar` as `http://host/bar` you can add a `strip=/foo`
-option to the route options as `urlprefix-/foo/bar strip=/foo`.
-


### PR DESCRIPTION
This page is a dupe of https://github.com/fabiolb/fabio/blob/master/docs/content/feature/http-path-stripping.md