### PR TITLE
add support for 'weight_tags=<t1>,<t2>,… ’ option on the url tag

### DIFF
--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -119,6 +119,7 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 
 				// build route command
 				weight := ""
+				weight_tags := ""
 				ropts := []string{}
 				tags := strings.Join(svctags, ",")
 				addr = net.JoinHostPort(addr, strconv.Itoa(port))
@@ -131,6 +132,8 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 						dst = "https://" + addr
 					case strings.HasPrefix(o, "weight="):
 						weight = o[len("weight="):]
+					case strings.HasPrefix(o, "weight_tags="):
+						weight_tags = o[len("weight_tags="):]
 					case strings.HasPrefix(o, "redirect="):
 						redir := strings.Split(o[len("redirect="):], ",")
 						if len(redir) == 2 {
@@ -146,7 +149,7 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 				}
 
 				cfg := "route add " + name + " " + route + " " + dst
-				if weight != "" {
+				if weight != "" && weight_tags == "" {
 					cfg += " weight " + weight
 				}
 				if tags != "" {
@@ -154,6 +157,9 @@ func serviceConfig(client *api.Client, name string, passing map[string]bool, tag
 				}
 				if len(ropts) > 0 {
 					cfg += " opts " + strconv.Quote(strings.Join(ropts, " "))
+				}
+				if weight != "" && weight_tags != "" {
+				        cfg += "\n route weight " + name + " " + route + " weight " + weight + " tags " + strconv.Quote(weight_tags)
 				}
 				config = append(config, cfg)
 			}


### PR DESCRIPTION
This patch add support to _'weight_tags=\<t1>,\<t2>,...’_ option on the url tag which permits to configure weight by tags on a service as per documentation:   _route weight \<src> weight \<w> tags "\<t1>,\<t2>,… "_
First use case would be an active/passive service. With a tag like _"urlprefix-vault.example.io/ weight=1 weight_tags=active"_ , Fabio would always route to the active node.
