### PR TITLE
Added new case insensitive matcher

### DIFF
--- a/config/load.go
+++ b/config/load.go
@@ -247,7 +247,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 		return nil, fmt.Errorf("invalid proxy.strategy: %s", cfg.Proxy.Strategy)
 	}
 
-	if cfg.Proxy.Matcher != "prefix" && cfg.Proxy.Matcher != "glob" && cfg.Proxy.Matcher != "noCase" {
+	if cfg.Proxy.Matcher != "prefix" && cfg.Proxy.Matcher != "glob" && cfg.Proxy.Matcher != "nocase" {
 		return nil, fmt.Errorf("invalid proxy.matcher: %s", cfg.Proxy.Matcher)
 	}
 

--- a/config/load.go
+++ b/config/load.go
@@ -247,7 +247,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 		return nil, fmt.Errorf("invalid proxy.strategy: %s", cfg.Proxy.Strategy)
 	}
 
-	if cfg.Proxy.Matcher != "prefix" && cfg.Proxy.Matcher != "glob" {
+	if cfg.Proxy.Matcher != "prefix" && cfg.Proxy.Matcher != "glob" && cfg.Proxy.Matcher != "noCase" {
 		return nil, fmt.Errorf("invalid proxy.matcher: %s", cfg.Proxy.Matcher)
 	}
 

--- a/config/load.go
+++ b/config/load.go
@@ -247,7 +247,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 		return nil, fmt.Errorf("invalid proxy.strategy: %s", cfg.Proxy.Strategy)
 	}
 
-	if cfg.Proxy.Matcher != "prefix" && cfg.Proxy.Matcher != "glob" && cfg.Proxy.Matcher != "nocase" {
+	if cfg.Proxy.Matcher != "prefix" && cfg.Proxy.Matcher != "glob" && cfg.Proxy.Matcher != "iprefix" {
 		return nil, fmt.Errorf("invalid proxy.matcher: %s", cfg.Proxy.Matcher)
 	}
 

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -307,6 +307,13 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			args: []string{"-proxy.matcher", "nocase"},
+			cfg: func(cfg *Config) *Config {
+				cfg.Proxy.Matcher = "nocase"
+				return cfg
+			},
+		},
+		{
 			args: []string{"-proxy.noroutestatus", "555"},
 			cfg: func(cfg *Config) *Config {
 				cfg.Proxy.NoRouteStatus = 555

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -307,9 +307,9 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			args: []string{"-proxy.matcher", "nocase"},
+			args: []string{"-proxy.matcher", "iprefix"},
 			cfg: func(cfg *Config) *Config {
-				cfg.Proxy.Matcher = "nocase"
+				cfg.Proxy.Matcher = "iprefix"
 				return cfg
 			},
 		},

--- a/docs/content/ref/proxy.matcher.md
+++ b/docs/content/ref/proxy.matcher.md
@@ -8,8 +8,8 @@ title: "proxy.matcher"
 * `prefix`: prefix matching
 * `glob`:  glob matching
 
-When `prefix` matching is enabled then the route path must be a 
-prefix of the request URI, e.g. `/foo` matches `/foo`, `/foot` but 
+When `prefix` matching is enabled then the route path must be a
+prefix of the request URI, e.g. `/foo` matches `/foo`, `/foot` but
 not `/fo`.
 
 When `glob` matching is enabled the route is evaluated according to
@@ -18,6 +18,8 @@ function.
 
 For example, `/foo*` matches `/foo`, `/fool` and `/fools`. Also, `/foo/*/bar`
 matches `/foo/x/bar`.
+
+`nocase` matching is similar to `prefix`, except it uses a case insensitive comparison
 
 The default is
 

--- a/docs/content/ref/proxy.matcher.md
+++ b/docs/content/ref/proxy.matcher.md
@@ -19,7 +19,7 @@ function.
 For example, `/foo*` matches `/foo`, `/fool` and `/fools`. Also, `/foo/*/bar`
 matches `/foo/x/bar`.
 
-`nocase` matching is similar to `prefix`, except it uses a case insensitive comparison
+`iprefix` matching is similar to `prefix`, except it uses a case insensitive comparison
 
 The default is
 

--- a/fabio.properties
+++ b/fabio.properties
@@ -297,7 +297,7 @@
 #
 # prefix: prefix matching
 # glob:  glob matching
-# nocase: matches using a case insensitive test
+# iprefix: case-insensitive prefix matching
 #
 # The default is
 #

--- a/fabio.properties
+++ b/fabio.properties
@@ -297,6 +297,7 @@
 #
 # prefix: prefix matching
 # glob:  glob matching
+# nocase: matches using a case insensitive test
 #
 # The default is
 #

--- a/route/matcher.go
+++ b/route/matcher.go
@@ -10,9 +10,9 @@ type matcher func(uri string, r *Route) bool
 // Matcher contains the available matcher functions.
 // Update config/load.go#load after updating.
 var Matcher = map[string]matcher{
-	"prefix": prefixMatcher,
-	"glob":   globMatcher,
-	"nocase": noCaseMatcher,
+	"prefix":  prefixMatcher,
+	"glob":    globMatcher,
+	"iprefix": iPrefixMatcher,
 }
 
 // prefixMatcher matches path to the routes' path.
@@ -25,8 +25,8 @@ func globMatcher(uri string, r *Route) bool {
 	return r.Glob.Match(uri)
 }
 
-// noCase matches path to the routes' path ignoring case
-func noCaseMatcher(uri string, r *Route) bool {
+// iPrefixMatcher matches path to the routes' path ignoring case
+func iPrefixMatcher(uri string, r *Route) bool {
 	lowerURI := strings.ToLower(uri)
 	lowerPath := strings.ToLower(r.Path)
 	return strings.HasPrefix(lowerURI, lowerPath)

--- a/route/matcher.go
+++ b/route/matcher.go
@@ -27,6 +27,8 @@ func globMatcher(uri string, r *Route) bool {
 
 // iPrefixMatcher matches path to the routes' path ignoring case
 func iPrefixMatcher(uri string, r *Route) bool {
+	// todo(fs): if this turns out to be a performance issue we should cache
+	// todo(fs): strings.ToLower(r.Path) in r.PathLower
 	lowerURI := strings.ToLower(uri)
 	lowerPath := strings.ToLower(r.Path)
 	return strings.HasPrefix(lowerURI, lowerPath)

--- a/route/matcher.go
+++ b/route/matcher.go
@@ -12,7 +12,7 @@ type matcher func(uri string, r *Route) bool
 var Matcher = map[string]matcher{
 	"prefix": prefixMatcher,
 	"glob":   globMatcher,
-	"noCase": noCaseMatcher,
+	"nocase": noCaseMatcher,
 }
 
 // prefixMatcher matches path to the routes' path.
@@ -27,5 +27,7 @@ func globMatcher(uri string, r *Route) bool {
 
 // noCase matches path to the routes' path ignoring case
 func noCaseMatcher(uri string, r *Route) bool {
-	return strings.EqualFold(uri, r.Path)
+	lowerURI := strings.ToLower(uri)
+	lowerPath := strings.ToLower(r.Path)
+	return strings.HasPrefix(lowerURI, lowerPath)
 }

--- a/route/matcher.go
+++ b/route/matcher.go
@@ -12,6 +12,7 @@ type matcher func(uri string, r *Route) bool
 var Matcher = map[string]matcher{
 	"prefix": prefixMatcher,
 	"glob":   globMatcher,
+	"noCase": noCaseMatcher,
 }
 
 // prefixMatcher matches path to the routes' path.
@@ -22,4 +23,9 @@ func prefixMatcher(uri string, r *Route) bool {
 // globMatcher matches path to the routes' path using gobwas/glob.
 func globMatcher(uri string, r *Route) bool {
 	return r.Glob.Match(uri)
+}
+
+// noCase matches path to the routes' path ignoring case
+func noCaseMatcher(uri string, r *Route) bool {
+	return strings.EqualFold(uri, r.Path)
 }

--- a/route/matcher_test.go
+++ b/route/matcher_test.go
@@ -61,7 +61,7 @@ func TestGlobMatcher(t *testing.T) {
 	}
 }
 
-func TestNoCaseMatcher(t *testing.T) {
+func TestIPrefixMatcher(t *testing.T) {
 	tests := []struct {
 		uri     string
 		matches bool
@@ -75,7 +75,7 @@ func TestNoCaseMatcher(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.uri, func(t *testing.T) {
-			if got, want := noCaseMatcher(tt.uri, tt.route), tt.matches; got != want {
+			if got, want := iPrefixMatcher(tt.uri, tt.route), tt.matches; got != want {
 				t.Fatalf("got %v want %v", got, want)
 			}
 		})

--- a/route/matcher_test.go
+++ b/route/matcher_test.go
@@ -60,3 +60,24 @@ func TestGlobMatcher(t *testing.T) {
 		})
 	}
 }
+
+func TestNoCaseMatcher(t *testing.T) {
+	tests := []struct {
+		uri     string
+		matches bool
+		route   *Route
+	}{
+		{uri: "/fool", matches: false, route: &Route{Path: "/foo"}},
+		{uri: "/foo", matches: true, route: &Route{Path: "/foo"}},
+		{uri: "/Foo", matches: true, route: &Route{Path: "/foo"}},
+		{uri: "/foo", matches: true, route: &Route{Path: "/Foo"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			if got, want := noCaseMatcher(tt.uri, tt.route), tt.matches; got != want {
+				t.Fatalf("got %v want %v", got, want)
+			}
+		})
+	}
+}

--- a/route/matcher_test.go
+++ b/route/matcher_test.go
@@ -67,9 +67,9 @@ func TestNoCaseMatcher(t *testing.T) {
 		matches bool
 		route   *Route
 	}{
-		{uri: "/fool", matches: false, route: &Route{Path: "/foo"}},
+		{uri: "/foo", matches: false, route: &Route{Path: "/fool"}},
 		{uri: "/foo", matches: true, route: &Route{Path: "/foo"}},
-		{uri: "/Foo", matches: true, route: &Route{Path: "/foo"}},
+		{uri: "/Fool", matches: true, route: &Route{Path: "/foo"}},
 		{uri: "/foo", matches: true, route: &Route{Path: "/Foo"}},
 	}
 


### PR DESCRIPTION
This adds the ability to have case insensitive matching for routes. This is important for projects that need to migrate from other load balancers that are case insensitive.