### PR TITLE
Implement basic auth htpasswd file refresh

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -170,6 +170,8 @@ type AuthScheme struct {
 }
 
 type BasicAuth struct {
-	Realm string
-	File  string
+	Realm   string
+	File    string
+	Refresh time.Duration
+	ModTime time.Time // the htpasswd file last modification time
 }

--- a/config/load.go
+++ b/config/load.go
@@ -613,8 +613,9 @@ func parseAuthScheme(cfg map[string]string) (a AuthScheme, err error) {
 		return AuthScheme{}, fmt.Errorf("missing 'type' in auth '%s'", a.Name)
 	case "basic":
 		a.Basic = BasicAuth{
-			File:  cfg["file"],
-			Realm: cfg["realm"],
+			File:    cfg["file"],
+			Realm:   cfg["realm"],
+			Refresh: 0, // the htpasswd file refresh is disabled by default
 		}
 
 		if a.Basic.File == "" {
@@ -623,6 +624,18 @@ func parseAuthScheme(cfg map[string]string) (a AuthScheme, err error) {
 		if a.Basic.Realm == "" {
 			a.Basic.Realm = a.Name
 		}
+
+		if cfg["refresh"] != "" {
+			d, err := time.ParseDuration(cfg["refresh"])
+			if err != nil {
+				return AuthScheme{}, err
+			}
+			if d < time.Second {
+				d = time.Second
+			}
+			a.Basic.Refresh = d
+		}
+
 	default:
 		return AuthScheme{}, fmt.Errorf("unknown auth type '%s'", a.Type)
 	}

--- a/docs/content/feature/authorization.md
+++ b/docs/content/feature/authorization.md
@@ -23,32 +23,33 @@ referenced in a route configuration.
 When you configure the route, you must reference the unique name for the authorization scheme:
 
     route add svc / https://127.0.0.1:8080 auth=<name>
-    
+
     urlprefix-/ proto=https auth=<name>
-    
+
 The following types of authorization schemes are available:
 
- * [`basic`](#basic): legacy store for a single TLS and a set of client auth certificates
- 
+* [`basic`](#basic): legacy store for a single TLS and a set of client auth certificates
+
 At the end you also find a list of [examples](#examples).
 
 ### Basic
 
 The basic authorization scheme leverages [Http Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication) and reads a [htpasswd](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html) file at startup and credentials are cached until the service exits.
 
-The `file` option contains the path to the htpasswd file. The `realm` parameter is optional (default is to use the `name`)  
+The `file` option contains the path to the htpasswd file. The `realm` parameter is optional (default is to use the `name`). The `refresh` option can set the htpasswd file refresh interval. Minimal refresh interval is `1s` to void busy loop. By default refresh is disabled i.e. set to zero.
 
-    name=<name>;type=basic;file=<file>;realm=<realm>
+    name=<name>;type=basic;file=<file>;realm=<realm>;refresh=<interval>
 
 Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpasswd)
 
-##### Examples
+#### Examples
 
-    # single basic auth scheme 
-    
+    # single basic auth scheme
     name=mybasicauth;type=basic;file=p/creds.htpasswd;
 
-    # basic auth with multiple schemes
+    # single basic auth scheme with refresh interval set to 30 seconds
+    name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
 
-    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd
+    # basic auth with multiple schemes
+    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
                  name=myotherauth;type=basic;file=p/other-creds.htpasswd;realm=myrealm

--- a/docs/content/ref/proxy.auth.md
+++ b/docs/content/ref/proxy.auth.md
@@ -17,23 +17,24 @@ The following types of authorization schemes are available:
 
 The basic authorization scheme leverages [Http Basic Auth](https://en.wikipedia.org/wiki/Basic_access_authentication) and reads a [htpasswd](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html) file at startup and credentials are cached until the service exits.
 
-The `file` option contains the path to the htpasswd file. The `realm` parameter is optional (default is to use the `name`)
+The `file` option contains the path to the htpasswd file. The `realm` parameter is optional (default is to use the `name`). The `refresh` option can set the htpasswd file refresh interval. Minimal refresh interval is `1s` to void busy loop. By default refresh is disabled i.e. set to zero.
 
-    name=<name>;type=basic;file=<file>;realm=<realm>
+    name=<name>;type=basic;file=<file>;realm=<realm>;refresh=<interval>
 
 Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpasswd)
 
 #### Examples
 
     # single basic auth scheme
-     
     name=mybasicauth;type=basic;file=p/creds.file;
 
+    # single basic auth scheme with refresh interval set to 30 seconds
+    name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
+
     # basic auth with multiple schemes
-    
-    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd
+    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
                  name=myotherauth;type=basic;file=p/other-creds.htpasswd;realm=myrealm
+
 The default is
 
-	proxy.auth =
-
+    proxy.auth =

--- a/fabio.properties
+++ b/fabio.properties
@@ -481,11 +481,15 @@
 # Basic
 #
 # The basic auth scheme leverages http basic authentication using
-# one htpasswd file which is loaded at startup and is cached until
-# the service exits.
+# one htpasswd file which is loaded at startup and by default is cached until
+# the service exits. However, it's possible to refresh htpasswd file
+# periodically by setting the refresh interval with 'refresh' option.
 #
 # The 'file' option contains the path to the htpasswd file. The 'realm'
-# option contains realm name (optional, default is the scheme name
+# option contains realm name (optional, default is the scheme name).
+# The 'refresh' option can set the htpasswd file refresh interval. Minimal
+# refresh interval is 1s to void busy loop.
+# By default refresh is disabled i.e. set to zero.
 #
 #   name=<name>;type=basic;file=p/creds.htpasswd;realm=foo
 #
@@ -494,6 +498,10 @@
 #   # single basic auth scheme
 #
 #   name=mybasicauth;type=basic;file=p/creds.htpasswd;
+#
+#   # single basic auth scheme with refresh interval set to 30 seconds
+#
+#   name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
 #
 #   # basic auth with multiple schemes
 #


### PR DESCRIPTION
Implemented basic auth htpasswd file refresh to avoid fabio restart on the htpasswd file change similarly to the cert store refresh.