### PR TITLE
Minimize load on busy Consul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ fabio.sublime-*
 demo/cert/
 /pkg/
 dist/
+custom.properties

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .DS_Store
 .idea
 .vagrant
+.vscode
 build/builds/
 fabio
 fabio.exe

--- a/registry/consul/matching.go
+++ b/registry/consul/matching.go
@@ -1,0 +1,24 @@
+package consul
+
+import (
+	"strings"
+
+	"github.com/hashicorp/consul/api"
+)
+
+func matchingServices(prefix string, checks []*api.HealthCheck) []*api.HealthCheck {
+	var matching []*api.HealthCheck
+	for _, hc := range checks {
+		if len(hc.ServiceTags) == 0 {
+			continue
+		}
+		for _, tag := range hc.ServiceTags {
+			if strings.HasPrefix(tag, prefix) {
+				matching = append(matching, hc)
+				continue
+			}
+		}
+	}
+
+	return matching
+}

--- a/registry/consul/matching_test.go
+++ b/registry/consul/matching_test.go
@@ -1,0 +1,55 @@
+package consul
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+)
+
+func TestMatchingServices(t *testing.T) {
+	var (
+		noTags      = &api.HealthCheck{}
+		noRoute     = &api.HealthCheck{ServiceTags: []string{}}
+		singleRoute = &api.HealthCheck{ServiceTags: []string{"route-/something"}}
+	)
+
+	tests := []struct {
+		name    string
+		prefix  string
+		in, out []*api.HealthCheck
+	}{
+		{
+			"expect match when tag starts correctly",
+			"route-", []*api.HealthCheck{singleRoute}, []*api.HealthCheck{singleRoute},
+		},
+		{
+			"expect no match when tag does not starts correctly",
+			"xxxxx-", []*api.HealthCheck{singleRoute}, nil,
+		},
+		{
+			"expect no match when no routes",
+			"route-", []*api.HealthCheck{noRoute}, nil,
+		},
+		{
+			"expect no match when no tags",
+			"route-", []*api.HealthCheck{noTags}, nil,
+		},
+		{
+			"expect no match when no input",
+			"route-", []*api.HealthCheck{}, nil,
+		},
+		{
+			"expect no match when no prefix",
+			"", []*api.HealthCheck{}, nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, want := matchingServices(tt.prefix, tt.in), tt.out; !reflect.DeepEqual(got, want) {
+				t.Errorf("got %v want %v", got, want)
+			}
+		})
+	}
+}

--- a/registry/consul/passing.go
+++ b/registry/consul/passing.go
@@ -48,7 +48,9 @@ func isServiceCheck(c *api.HealthCheck) bool {
 func isAgentCritical(svc *api.HealthCheck, checks []*api.HealthCheck) bool {
 	for _, c := range checks {
 		if svc.Node == c.Node && c.CheckID == "serfHealth" && c.Status == "critical" {
-			log.Printf("[DEBUG] consul: Skipping service %q since agent on node %q is down: %s", c.ServiceID, c.Node, c.Output)
+			if c.ServiceID != "" {
+				log.Printf("[DEBUG] consul: Skipping service %q since agent on node %q is down: %s", c.ServiceID, c.Node, c.Output)
+			}
 			return true
 		}
 	}

--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -50,7 +50,7 @@ func (w *ServiceMonitor) Watch(updates chan<- string) {
 		passing := passingServices(checks, w.config.ServiceStatus, w.strict)
 
 		// limit to services which have the required tag prefix
-		passing = matchingServices(w.config.TagPrefix, checks)
+		passing = matchingServices(w.config.TagPrefix, passing)
 
 		// greate a sorted list of unique passing ids
 		passingIds := make([]string, len(passing))


### PR DESCRIPTION
The current Fabio strategy for watching Consul services is to monitor globally for any health check changes, then query the Consul Catalog once for every passing service in Consul, then update the routing table with the changes. With enough Fabio instances, this strategy can generate significant load on larger Consul installations, due to the volume of health changes, and the large number of services that are each checked individually. 

In our specific case, we have many Fabio instances, but are routing only a few services in Consul.  Many changes in health are not relevant to our Fabio routing. This PR makes 2 adjustments in order to lighten the load:

1) Only query the catalog if the service has a matching tag prefix
2) Only query the catalog when something changed (many health check changes do not alter the status of any of the watched services).

