### PR TITLE
fix exit status code

### DIFF
--- a/proxy/serve.go
+++ b/proxy/serve.go
@@ -103,5 +103,8 @@ func serve(ln net.Listener, srv Server) error {
 	mu.Lock()
 	servers = append(servers, srv)
 	mu.Unlock()
-	return srv.Serve(ln)
+	if err := srv.Serve(ln); err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Fabio always returned status code 1. Even on clean exit.
Shutdown of http server is treated as fatal:
 ```
[FATAL] http: Server closed
[FATAL] ui: http: Server closed
```

HTTP server [Serve](https://golang.org/pkg/net/http/#Server.Serve) method always returns non nil error.

ErrServerClosed should be treated as clean exit.
> After Shutdown or Close, the returned error is ErrServerClosed."