### PR TITLE
ui: Remove duplicate destination column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,11 @@
 
   Thanks to [@stack72](https://github.com/stack72) for the patch.
 
-* [PR #583](https://github.com/fabiolb/fabio/pull/583): Make dest column clickable
+* [PR #583](https://github.com/fabiolb/fabio/pull/583): Update PROXY protocol docs
 
   This patch updates the documentation around the PROXY protocol.
 
-  Thanks to [@pschultz](https://github.com/pschultz).
+  Thanks to [@leprechau](https://github.com/leprechau).
 
 * [PR #587](https://github.com/fabiolb/fabio/pull/587): Make dest column clickable
 

--- a/admin/ui/route.go
+++ b/admin/ui/route.go
@@ -95,7 +95,6 @@ $(function(){
 			$tr.append($('<td />').text(i+1));
 			$tr.append($('<td />').text(r.service));
 			$tr.append($('<td />').text(r.src));
-			$tr.append($('<td />').text(r.dst));
 			$tr.append($('<td />').append($('<a />').attr('href', r.dst).text(r.dst)));
 			$tr.append($('<td />').text(r.opts));
 			$tr.append($('<td />').text((r.weight * 100).toFixed(2) + '%'));


### PR DESCRIPTION
#587 duplicated the destination column in the route UI instead of replacing it, probably as a result of resolving the merge conflict with #588.

Fixes #628.
