### PR TITLE
Handle context canceled errors + better http proxy error handling

### DIFF
--- a/proxy/http_handler.go
+++ b/proxy/http_handler.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func newHTTPProxy(target *url.URL, tr http.RoundTripper, flush time.Duration) http.Handler {
+func newHTTPProxy(target *url.URL, tr http.RoundTripper, flush time.Duration, errorHandler func(http.ResponseWriter, *http.Request, error)) http.Handler {
 	return &httputil.ReverseProxy{
 		// this is a simplified director function based on the
 		// httputil.NewSingleHostReverseProxy() which does not
@@ -25,5 +25,6 @@ func newHTTPProxy(target *url.URL, tr http.RoundTripper, flush time.Duration) ht
 		},
 		FlushInterval: flush,
 		Transport:     tr,
+		ErrorHandler:  errorHandler,
 	}
 }

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -188,10 +187,10 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case accept == "text/event-stream":
 		// use the flush interval for SSE (server-sent events)
 		// must be > 0s to be effective
-		h = newHTTPProxy(targetURL, tr, p.Config.FlushInterval, httpProxyErrorHandler)
+		h = newHTTPProxy(targetURL, tr, p.Config.FlushInterval)
 
 	default:
-		h = newHTTPProxy(targetURL, tr, p.Config.GlobalFlushInterval, httpProxyErrorHandler)
+		h = newHTTPProxy(targetURL, tr, p.Config.GlobalFlushInterval)
 	}
 
 	if p.Config.GZIPContentTypes != nil {
@@ -237,19 +236,6 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			UpstreamURL:     targetURL,
 		})
 	}
-}
-
-func httpProxyErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	// According to https://golang.org/src/net/http/httputil/reverseproxy.go#L74, Go will return a 502 (Bad Gateway) StatusCode by default if no ErroHandler is provided
-	// If a "context canceled" error is returned by the http.Request handler this means the client closed the connection before getting a response
-	// So we are changing the StatusCode on these situations to the non-standard 499 (Client Closed Connection)
-	if rErr := r.Context().Err(); rErr != nil && rErr.Error() == "context canceled" {
-		w.WriteHeader(499)
-	} else if err != nil {
-		log.Printf("[ERROR] %s", err.Error())
-		w.WriteHeader(504)
-	}
-	return
 }
 
 func key(code int) string {


### PR DESCRIPTION
This PR fixes how fabio is handling the HTTP/HTTPS proxy "context canceled" errors that are caused basically by the client side closing the connection before getting any response and wrongly reporting a 502 status code in the logs. This is specially annoying for systems like Nomad that use long polling API endpoints and whenever you navigate in the UI, you are constantly closing the long polled connection and getting the `context canceled` error in the logs.

Along with the fix, we are using the HTTP Status Code [499](https://httpstatuses.com/499) which is a non standard status code created by Nginx to represent `Client Closed Request` responses.

Since Fabio also supports HTTP/2, this also solves misleading logs reporting 502 responses when HTTP/2 is used... The HTTP/2 RFC allows a client to close a request connection when the requested resources are already in cache.

I've tested these changes in our internal QA environment and stderr logging is also improved by using the HTTP Proxy ErrorHandler along with `context canceled` being correctly handled.

Closes #264 