### PR TITLE
ensure absolute path after strip to maintain rfc complaince

### DIFF
--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -150,6 +150,11 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO(fs): a defensive approach.
 	if t.StripPath != "" && strings.HasPrefix(r.URL.Path, t.StripPath) {
 		targetURL.Path = targetURL.Path[len(t.StripPath):]
+		// ensure absolute path after stripping to maintain compliance with
+		// section 5.1.2 of RFC2616 (https://tools.ietf.org/html/rfc2616#section-5.1.2)
+		if !strings.HasPrefix(targetURL.Path, "/") {
+			targetURL.Path = "/" + targetURL.Path
+		}
 	}
 
 	if err := addHeaders(r, p.Config, t.StripPath); err != nil {

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -151,7 +151,7 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if t.StripPath != "" && strings.HasPrefix(r.URL.Path, t.StripPath) {
 		targetURL.Path = targetURL.Path[len(t.StripPath):]
 		// ensure absolute path after stripping to maintain compliance with
-		// section 5.1.2 of RFC2616 (https://tools.ietf.org/html/rfc2616#section-5.1.2)
+		// section 5.3 of RFC7230 (https://tools.ietf.org/html/rfc7230#section-5.3)
 		if !strings.HasPrefix(targetURL.Path, "/") {
 			targetURL.Path = "/" + targetURL.Path
 		}


### PR DESCRIPTION
It's easy to inadvertently remove the leading slash from the request path when stripping which results in sending a malformed GET with a relative path to the backend server.

Example below ...

Origin URL:
```
http://foo.com/apples/oranges/steve.html
```

Route:
``` 
route add strippy /apples/ http://1.2.3.4:80/ opts "strip=/apples/"
```

Results in sending `GET oranges/steve.html` to the 1.2.3.4 backend.  Proper GET request should always be an absolute path or absolute URI according to the RFC (https://tools.ietf.org/html/rfc2616#section-5.1.2).


