### PR TITLE
Fix SSE by implementing Flusher in responseWriter wrapper

### DIFF
--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -273,6 +273,12 @@ func (rw *responseWriter) WriteHeader(statusCode int) {
 	rw.code = statusCode
 }
 
+func (rw *responseWriter) Flush() {
+	if fl, ok := rw.w.(http.Flusher); ok {
+		fl.Flush()
+	}
+}
+
 var errNoHijacker = errors.New("not a hijacker")
 
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {


### PR DESCRIPTION
I noticed after upgrading to any version later than 1.5.8 that server-sent events stopped working. It looks like the responseWriter wrapper added in #470 does not implement the `http.Flusher` interface, so events are never flushed to the client.

Adding `Flush()` to the wrapper fixes the issue and server-sent events are working for me again.