### PR TITLE
config: let registry.consul.register.addr default to ui.addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ### Unreleased
 
+#### Breaking Changes
+
+* [Issue #657](https://github.com/fabiolb/fabio/issues/657): Fix default registration address
+
+  fabio used to register its UI in Consul with address `:9998`, even if
+  `-ui.addr` was set to a different value. That made it necessary to specify
+  both `-ui.addr` and `-registry.consul.register.addr` in most cases. Now
+  `-registry.consul.register.addr` defaults to the value of `-ui.addr`.
+
+  If you set `-ui.addr` to something other than `:9998` and intentionally
+  omitted the `-registry.consul.register.addr` flag (because the UI is behind a
+  proxy, for instance), you will now have to set `-registry.consul.register.addr=:9998`
+  to get the previous behavior.
+
+  Thanks to [@ttais2017](https://github.com/ttais2017) for the report.
+
 #### Improvements
 
 * [PR #620](https://github.com/fabiolb/fabio/pull/620): Read Vault token from file

--- a/config/load.go
+++ b/config/load.go
@@ -179,7 +179,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.StringVar(&cfg.Registry.Consul.TLS.CAPath, "registry.consul.tls.capath", defaultConfig.Registry.Consul.TLS.CAPath, "path to consul CA directory")
 	f.BoolVar(&cfg.Registry.Consul.TLS.InsecureSkipVerify, "registry.consul.tls.insecureskipverify", defaultConfig.Registry.Consul.TLS.InsecureSkipVerify, "is tls check enabled")
 	f.BoolVar(&cfg.Registry.Consul.Register, "registry.consul.register.enabled", defaultConfig.Registry.Consul.Register, "register fabio in consul")
-	f.StringVar(&cfg.Registry.Consul.ServiceAddr, "registry.consul.register.addr", defaultConfig.Registry.Consul.ServiceAddr, "service registration address")
+	f.StringVar(&cfg.Registry.Consul.ServiceAddr, "registry.consul.register.addr", "<ui.addr>", "service registration address")
 	f.StringVar(&cfg.Registry.Consul.ServiceName, "registry.consul.register.name", defaultConfig.Registry.Consul.ServiceName, "service registration name")
 	f.StringSliceVar(&cfg.Registry.Consul.ServiceTags, "registry.consul.register.tags", defaultConfig.Registry.Consul.ServiceTags, "service registration tags")
 	f.StringSliceVar(&cfg.Registry.Consul.ServiceStatus, "registry.consul.service.status", defaultConfig.Registry.Consul.ServiceStatus, "valid service status values")
@@ -272,6 +272,11 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 		}
 	}
 
+	// Unless registry.consul.register.addr has been set explicitly it should
+	// be the same as ui.addr. See issue 657.
+	if !f.IsSet("registry.consul.register.addr") {
+		cfg.Registry.Consul.ServiceAddr = cfg.UI.Listen.Addr
+	}
 	if cfg.Registry.Consul.ServiceAddr != "" {
 		if cfg.Registry.Consul.ServiceAddr, err = gs.Parse(cfg.Registry.Consul.ServiceAddr); err != nil {
 			return nil, fmt.Errorf("failed to consul service address: %s", err)

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -874,6 +874,7 @@ func TestLoad(t *testing.T) {
 			cfg: func(cfg *Config) *Config {
 				cfg.UI.Listen.Addr = "1.2.3.4:5555"
 				cfg.UI.Listen.Proto = "http"
+				cfg.Registry.Consul.ServiceAddr = "1.2.3.4:5555"
 				return cfg
 			},
 		},
@@ -886,6 +887,7 @@ func TestLoad(t *testing.T) {
 				cfg.UI.Listen.CertSource.Type = "file"
 				cfg.UI.Listen.CertSource.CertPath = "value"
 				cfg.Registry.Consul.CheckScheme = "https"
+				cfg.Registry.Consul.ServiceAddr = ":9998"
 				return cfg
 			},
 		},


### PR DESCRIPTION
Always set registry.consul.register.addr to the value of ui.addr if the
flag hasn't been specified.

Fixes #657.