### PR TITLE
Add config option to use 128 bit trace IDs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -175,6 +175,7 @@ type Tracing struct {
 	Topic          string
 	SamplerRate    float64
 	SpanHost       string
+	TraceID128Bit  bool
 }
 
 type AuthScheme struct {

--- a/config/default.go
+++ b/config/default.go
@@ -100,5 +100,6 @@ var defaultConfig = &Config{
 		Topic:          "Fabiolb-Kafka-Topic",
 		SamplerRate:    -1,
 		SpanHost:       "localhost:9998",
+		TraceID128Bit:  true,
 	},
 }

--- a/config/load.go
+++ b/config/load.go
@@ -204,6 +204,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.StringVar(&cfg.Tracing.Topic, "tracing.Topic", defaultConfig.Tracing.Topic, "OpenTrace Collector Kafka Topic")
 	f.Float64Var(&cfg.Tracing.SamplerRate, "tracing.SamplerRate", defaultConfig.Tracing.SamplerRate, "OpenTrace sample rate percentage in decimal form")
 	f.StringVar(&cfg.Tracing.SpanHost, "tracing.SpanHost", defaultConfig.Tracing.SpanHost, "Host:Port info to add to spans")
+	f.BoolVar(&cfg.Tracing.TraceID128Bit, "tracing.TraceID128Bit", defaultConfig.Tracing.TraceID128Bit, "Generate 128 bit trace IDs")
 	f.BoolVar(&cfg.GlobMatchingDisabled, "glob.matching.disabled", defaultConfig.GlobMatchingDisabled, "Disable Glob Matching on routes, one of [true, false]")
 
 	f.StringVar(&cfg.Registry.Custom.Host, "registry.custom.host", defaultConfig.Registry.Custom.Host, "custom back end hostname/port")

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -47,12 +47,12 @@ func CreateCollector(collectorType, connectString, topic string) zipkin.Collecto
 	return collector
 }
 
-func CreateTracer(recorder zipkin.SpanRecorder, samplerRate float64) opentracing.Tracer {
+func CreateTracer(recorder zipkin.SpanRecorder, samplerRate float64, traceID128Bit bool) opentracing.Tracer {
 	tracer, err := zipkin.NewTracer(
 		recorder,
 		zipkin.WithSampler(zipkin.NewBoundarySampler(samplerRate, 1)),
 		zipkin.ClientServerSameSpan(false),
-		zipkin.TraceID128Bit(true),
+		zipkin.TraceID128Bit(traceID128Bit),
 	)
 
 	if err != nil {
@@ -93,7 +93,7 @@ func InitializeTracer(traceConfig *config.Tracing) {
 	// Create a new Zipkin Collector, Recorder, and Tracer
 	collector := CreateCollector(traceConfig.CollectorType, traceConfig.ConnectString, traceConfig.Topic)
 	recorder := zipkin.NewRecorder(collector, false, traceConfig.SpanHost, traceConfig.ServiceName)
-	tracer := CreateTracer(recorder, traceConfig.SamplerRate)
+	tracer := CreateTracer(recorder, traceConfig.SamplerRate, traceConfig.TraceID128Bit)
 
 	// Set the Zipkin Tracer created above to the GlobalTracer
 	opentracing.SetGlobalTracer(tracer)


### PR DESCRIPTION
Parts of our stack don't yet support 128 bit trace IDs, which Fabio is currently generating by default. This adds a config option to disable these, with the value defaulting to true to maintain backwards compatibility.