### PR TITLE
Implement new config to override service host with consul advertise ip

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -154,6 +154,7 @@ type Consul struct {
 	ChecksRequired                      string
 	ServiceMonitors                     int
 	TLS                                 ConsulTlS
+	UseConsulServiceAddr				bool
 }
 
 type Custom struct {

--- a/config/default.go
+++ b/config/default.go
@@ -65,6 +65,7 @@ var defaultConfig = &Config{
 			CheckScheme:                         "http",
 			CheckDeregisterCriticalServiceAfter: "90m",
 			ChecksRequired:                      "one",
+			UseConsulServiceAddr:				 false,
 		},
 		Custom: Custom{
 			Host:               "",

--- a/config/load.go
+++ b/config/load.go
@@ -173,6 +173,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.StringVar(&cfg.Registry.Consul.KVPath, "registry.consul.kvpath", defaultConfig.Registry.Consul.KVPath, "consul KV path for manual overrides")
 	f.StringVar(&cfg.Registry.Consul.NoRouteHTMLPath, "registry.consul.noroutehtmlpath", defaultConfig.Registry.Consul.NoRouteHTMLPath, "consul KV path for HTML returned when no route is found")
 	f.StringVar(&cfg.Registry.Consul.TagPrefix, "registry.consul.tagprefix", defaultConfig.Registry.Consul.TagPrefix, "prefix for consul tags")
+	f.BoolVar(&cfg.Registry.Consul.UseConsulServiceAddr, "registry.consul.useconsulserviceaddr", defaultConfig.Registry.Consul.UseConsulServiceAddr, "Use consul address instead of service address")
 	f.StringVar(&cfg.Registry.Consul.TLS.KeyFile, "registry.consul.tls.keyfile", defaultConfig.Registry.Consul.TLS.KeyFile, "path to consul key file")
 	f.StringVar(&cfg.Registry.Consul.TLS.CertFile, "registry.consul.tls.certfile", defaultConfig.Registry.Consul.TLS.CertFile, "path to consul cert file")
 	f.StringVar(&cfg.Registry.Consul.TLS.CAFile, "registry.consul.tls.cafile", defaultConfig.Registry.Consul.TLS.CAFile, "path to consul CA file")

--- a/fabio.properties
+++ b/fabio.properties
@@ -777,6 +777,17 @@
 # registry.consul.tagprefix = urlprefix-
 
 
+# registry.consul.useconsulserviceaddr configures the behaivour for overriding the address
+#
+# Nomad in combination with Consul often register a service with an internal IP
+# Nomad doesn't not respect currently to register services with the advertisement IP
+# With this setting all services host ip will be ignored and the consul advertise IP
+# will be registered.
+# 
+# The default is
+# registry.consul.useconsulserviceaddr = false
+
+
 # registry.consul.register.enabled configures whether fabio registers itself in consul.
 #
 # Fabio will register itself in consul only if this value is set to "true" which

--- a/registry/consul/routecmd.go
+++ b/registry/consul/routecmd.go
@@ -21,6 +21,8 @@ type routecmd struct {
 	prefix string
 
 	env map[string]string
+
+	useConsulAddress bool
 }
 
 func (r routecmd) build() []string {
@@ -40,7 +42,7 @@ func (r routecmd) build() []string {
 			name, addr, port := r.svc.ServiceName, r.svc.ServiceAddress, r.svc.ServicePort
 
 			// use consul node address if service address is not set
-			if addr == "" {
+			if r.useConsulAddress || addr == "" {
 				addr = r.svc.Address
 			}
 

--- a/registry/consul/service.go
+++ b/registry/consul/service.go
@@ -126,6 +126,7 @@ func (w *ServiceMonitor) serviceConfig(name string, passing map[string]bool) (co
 			svc:    svc,
 			env:    env,
 			prefix: w.config.TagPrefix,
+			useConsulAddress: w.config.UseConsulServiceAddr,
 		}
 		cmds := r.build()
 


### PR DESCRIPTION
Nomad in combination with Consul often register a service with an internal IP
Nomad doesn't respect to register services with the advertisement IP

With this setting all services host IP will be ignored and the consul advertise IP will be registered.