### PR TITLE
Safely handle missing cert from Vault KV store

### DIFF
--- a/cert/vault_source.go
+++ b/cert/vault_source.go
@@ -117,6 +117,10 @@ func (s *VaultSource) load(path string) (pemBlocks map[string][]byte, err error)
 			log.Printf("[WARN] cert: Failed to read %s from Vault: %s", p, err)
 			continue
 		}
+		if secret == nil {
+			log.Printf("[WARN] cert: Failed to find %s in Vault: %s", p, err)
+			continue
+		}
 		get(name, "cert", secret, v2)
 		get(name, "key", secret, v2)
 	}


### PR DESCRIPTION
I have certificates saved in Vault using its KV engine version 2, and Fabio started panicking after I deleted an unused certificate. The fix was to run `vault kv metadata delete <cert>` to clean up the metadata as well, but Fabio should be able to avoid panicking in this case.