### PR TITLE
Add HTTP method and path to trace span operation name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -175,6 +175,7 @@ type Tracing struct {
 	Topic          string
 	SamplerRate    float64
 	SpanHost       string
+	SpanName       string
 	TraceID128Bit  bool
 }
 

--- a/config/default.go
+++ b/config/default.go
@@ -100,6 +100,7 @@ var defaultConfig = &Config{
 		Topic:          "Fabiolb-Kafka-Topic",
 		SamplerRate:    -1,
 		SpanHost:       "localhost:9998",
+		SpanName:       "",
 		TraceID128Bit:  true,
 	},
 }

--- a/config/load.go
+++ b/config/load.go
@@ -201,6 +201,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.StringVar(&cfg.Tracing.CollectorType, "tracing.CollectorType", defaultConfig.Tracing.CollectorType, "OpenTrace Collector Type, one of [http, kafka]")
 	f.StringVar(&cfg.Tracing.ConnectString, "tracing.ConnectString", defaultConfig.Tracing.ConnectString, "OpenTrace Collector host:port")
 	f.StringVar(&cfg.Tracing.ServiceName, "tracing.ServiceName", defaultConfig.Tracing.ServiceName, "Service name to embed in OpenTrace span")
+	f.StringVar(&cfg.Tracing.SpanName, "tracing.SpanName", defaultConfig.Tracing.SpanName, "Span name template used to embed in OpenTrace span")
 	f.StringVar(&cfg.Tracing.Topic, "tracing.Topic", defaultConfig.Tracing.Topic, "OpenTrace Collector Kafka Topic")
 	f.Float64Var(&cfg.Tracing.SamplerRate, "tracing.SamplerRate", defaultConfig.Tracing.SamplerRate, "OpenTrace sample rate percentage in decimal form")
 	f.StringVar(&cfg.Tracing.SpanHost, "tracing.SpanHost", defaultConfig.Tracing.SpanHost, "Host:Port info to add to spans")

--- a/fabio.properties
+++ b/fabio.properties
@@ -1261,6 +1261,28 @@
 # tracing.ServiceName = Fabiolb
 
 
+# tracing.SpanName configures the template used in reporting span information
+#
+# The value is expanded by the text/template package and provides
+# the following variables:
+#
+#  - Proto:       the protocol version
+#  - Method:      the HTTP method
+#  - Host:        the host part of the URL
+#  - Scheme:      the scheme of the requested URL
+#  - Path:        the path of the requested URL
+#  - RawQuery:    the encoded query values of the requested URL
+#
+# SpanName defaults to the value of tracing.ServiceName but can be
+# overridden with this property.
+#
+# Example: tracing.SpanName = {{.Proto}} {{.Method}} {{.Path}}
+#
+# The default is
+#
+# tracing.SpanName =
+
+
 # tracing.Topic sets the Topic String used if tracing.CollectorType is kafka and
 # tracing.ConnectSting is set to a kafka broker
 #
@@ -1284,4 +1306,3 @@
 #
 # The default is
 # tracing.SpanHost = localhost:9998
-

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -80,7 +80,7 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//Create Span
-	span := trace.CreateSpan(r, p.TracerCfg.ServiceName)
+	span := trace.CreateSpan(r)
 	defer span.Finish()
 
 	t := p.Lookup(r)

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -55,7 +55,7 @@ type HTTPProxy struct {
 	// Logger is the access logger for the requests.
 	Logger logger.Logger
 
-	// TracerCfg is the Open Tracing  configuration as provided during startup
+	// TracerCfg is the Open Tracing configuration as provided during startup
 	TracerCfg config.Tracing
 
 	// UUID returns a unique id in uuid format.
@@ -80,7 +80,7 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//Create Span
-	span := trace.CreateSpan(r)
+	span := trace.CreateSpan(r, &p.TracerCfg)
 	defer span.Finish()
 
 	t := p.Lookup(r)

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -24,7 +24,7 @@ func TestCreateSpanNoGlobalTracer(t *testing.T) {
 	opentracing.SetGlobalTracer(nil)
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 
-	if CreateSpan(req, testServiceName) != nil {
+	if CreateSpan(req) != nil {
 		t.Error("CreateSpan returned a non-nil result using a nil global tracer.")
 		t.Fail()
 	}
@@ -35,7 +35,7 @@ func TestCreateSpanWithNoParent(t *testing.T) {
 	opentracing.SetGlobalTracer(tracer)
 
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
-	if CreateSpan(req, testServiceName) == nil {
+	if CreateSpan(req) == nil {
 		t.Error("Received nil span while a global tracer was set.")
 		t.FailNow()
 	}
@@ -53,7 +53,7 @@ func TestCreateSpanWithParent(t *testing.T) {
 		opentracing.HTTPHeadersCarrier(requestIn.Header),
 	)
 
-	if CreateSpan(requestIn, testServiceName+"-child") == nil {
+	if CreateSpan(requestIn) == nil {
 		t.Error("Received a nil span while a global tracer was set.")
 		t.FailNow()
 	}

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -24,7 +24,7 @@ func TestCreateSpanNoGlobalTracer(t *testing.T) {
 	opentracing.SetGlobalTracer(nil)
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
 
-	if CreateSpan(req) != nil {
+	if CreateSpan(req, &config.Tracing{ServiceName: "fabiolb-test", SpanName: "{{.Method}} {{.Path}}"}) != nil {
 		t.Error("CreateSpan returned a non-nil result using a nil global tracer.")
 		t.Fail()
 	}
@@ -35,7 +35,7 @@ func TestCreateSpanWithNoParent(t *testing.T) {
 	opentracing.SetGlobalTracer(tracer)
 
 	req, _ := http.NewRequest("GET", "http://example.com", nil)
-	if CreateSpan(req) == nil {
+	if CreateSpan(req, &config.Tracing{ServiceName: "fabiolb-test", SpanName: "{{.Method}} {{.Path}}"}) == nil {
 		t.Error("Received nil span while a global tracer was set.")
 		t.FailNow()
 	}
@@ -53,7 +53,7 @@ func TestCreateSpanWithParent(t *testing.T) {
 		opentracing.HTTPHeadersCarrier(requestIn.Header),
 	)
 
-	if CreateSpan(requestIn) == nil {
+	if CreateSpan(requestIn, &config.Tracing{ServiceName: "fabiolb-test", SpanName: "{{.Method}} {{.Path}}"}) == nil {
 		t.Error("Received a nil span while a global tracer was set.")
 		t.FailNow()
 	}
@@ -125,6 +125,25 @@ func TestInjectHeadersWithParentSpan(t *testing.T) {
 	}
 	if req.Header.Get("x-B3-Traceid") != "00000000000004d200000000000010e1" {
 		t.Error("Inject did not reuse the Traceid from the parent span")
+		t.Fail()
+	}
+}
+
+func TestSpanName(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com/demo", nil)
+
+	if spanName("{{.Method}} {{.Host}} {{.Path}}", req) != "GET example.com /demo" {
+		t.Error("spanName did not properly render the supported template")
+		t.Fail()
+	}
+
+	if spanName("{{.Invalid", req) != "{{.Invalid" {
+		t.Error("spanName did not return the unrendered string of the invalid template")
+		t.Fail()
+	}
+
+	if spanName("{{.Unsupported}}", req) != "{{.Unsupported}}" {
+		t.Error("spanName did not return the unrendered string of the unsupported template")
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Edit: addresses https://github.com/fabiolb/fabio/issues/732

The current tracing implementation sets the `operationName` of every fabio span to the configured tracing service name. This makes it difficult to distinguish between traces in the Jaeger UI, as seen here (this is with `FABIO_TRACING_SERVICENAME` set to `fabio`):

<img width="1140" alt="jaeger-fabio" src="https://user-images.githubusercontent.com/3260244/67521263-28099f00-f670-11e9-93cc-4ab638515a2f.png">

This commit sets the `operationName` to `HTTP <REQUST_METHOD> <REQUEST_PATH>` so that traces are easier to identify:

<img width="1135" alt="jaeger-fabio-detail" src="https://user-images.githubusercontent.com/3260244/67521464-8afb3600-f670-11e9-811f-c2ce62dc8188.png">

It also sets the `http.method` and `http.url` tags on the span. To set the value of `http.url` it uses `req.URL.String()`, which resolves to the request path rather than the full URL (presumably because `Scheme` and `Host` are unset in the URL struct: https://golang.org/pkg/net/url/#URL.String). This is sufficient for our purposes but can be addressed if needed.