### PR TITLE
add path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,3 +108,5 @@ require (
 )
 
 go 1.13
+
+replace go.uber.org/atomic => github.com/uber-go/atomic v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6 h1:lYIiVD
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/ugorji/go/codec v0.0.0-20181022190402-e5e69e061d4f h1:y3Vj7GoDdcBkxFa2RUUFKM25TrBbWVDnjRDI0u975zQ=
 github.com/ugorji/go/codec v0.0.0-20181022190402-e5e69e061d4f/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4MEFmbnK4h3BD7AUmskWv2+EeZJCCs=

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -157,6 +157,13 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if t.AddPath != "" {
+		targetURL.Path = t.AddPath + targetURL.Path
+		if !strings.HasPrefix(targetURL.Path, "/") {
+			targetURL.Path = "/" + targetURL.Path
+		}
+	}
+
 	if err := addHeaders(r, p.Config, t.StripPath); err != nil {
 		http.Error(w, "cannot parse "+r.RemoteAddr, http.StatusInternalServerError)
 		return

--- a/route/route.go
+++ b/route/route.go
@@ -72,6 +72,7 @@ func (r *Route) addTarget(service string, targetURL *url.URL, fixedWeight float6
 
 	if opts != nil {
 		t.StripPath = opts["strip"]
+		t.AddPath = opts["add"]
 		t.TLSSkipVerify = opts["tlsskipverify"] == "true"
 		t.Host = opts["host"]
 		t.ProxyProto = opts["pxyproto"] == "true"

--- a/route/target.go
+++ b/route/target.go
@@ -21,6 +21,10 @@ type Target struct {
 	// request path
 	StripPath string
 
+	//AddPath will be add to the front of the outgoing request path,
+	//who's priority is lower than StripPath
+	AddPath string
+
 	// TLSSkipVerify disables certificate validation for upstream
 	// TLS connections.
 	TLSSkipVerify bool


### PR DESCRIPTION
fabio supports stripping a path from the incoming request. If you want to forward http://host/foo/bar as http://host/bar you can add a strip=/foo option to the route options as urlprefix-/foo/bar strip=/foo. But, sometimes, need to add pre path.