### PR TITLE
Fix infinite buffering of SSE responses when gzip is enabled

### DIFF
--- a/proxy/gzip/gzip_handler.go
+++ b/proxy/gzip/gzip_handler.go
@@ -21,12 +21,15 @@ import (
 
 const (
 	headerVary            = "Vary"
+	headerAccept          = "Accept"
 	headerAcceptEncoding  = "Accept-Encoding"
 	headerContentEncoding = "Content-Encoding"
 	headerContentType     = "Content-Type"
 	headerContentLength   = "Content-Length"
 	encodingGzip          = "gzip"
 )
+
+var blacklistedAcceptContentTypes = []string{"text/event-stream"}
 
 var gzipWriterPool = sync.Pool{
 	New: func() interface{} { return gzip.NewWriter(nil) },
@@ -110,5 +113,11 @@ func isCompressable(header http.Header, contentTypes *regexp.Regexp) bool {
 }
 
 func acceptsGzip(r *http.Request) bool {
+	accept := r.Header.Get(headerAccept)
+	for _, contentType := range blacklistedAcceptContentTypes {
+		if strings.Contains(accept, contentType) {
+			return false
+		}
+	}
 	return strings.Contains(r.Header.Get(headerAcceptEncoding), encodingGzip)
 }


### PR DESCRIPTION
SSE requests (`text/event-stream`) don't work properly (no events are transmitted to the client) if `proxy.gzip.contenttype` is non-nil and gzip is in the `Accept-Encoding` header, because under those conditions the response gets chained through `GzipResponseWriter` even if no compression is being done. This change will bypass the `GzipResponseWriter` if there is a `Accept: text/event-stream` header.