### PR TITLE
Add `only=` tag

### DIFF
--- a/registry/consul/routecmd.go
+++ b/registry/consul/routecmd.go
@@ -55,6 +55,7 @@ func (r routecmd) build() []string {
 
 			var weight string
 			var ropts []string
+			var only string
 			for _, o := range strings.Fields(opts) {
 				switch {
 				case o == "proto=tcp":
@@ -68,6 +69,9 @@ func (r routecmd) build() []string {
 
 				case o == "proto=grpc":
 					dst = "grpc://" + addr
+
+				case strings.HasPrefix(o, "only="):
+					only = o[len("only="):]
 
 				case strings.HasPrefix(o, "weight="):
 					weight = o[len("weight="):]
@@ -86,18 +90,20 @@ func (r routecmd) build() []string {
 				}
 			}
 
-			cfg := "route add " + name + " " + route + " " + dst
-			if weight != "" {
-				cfg += " weight " + weight
-			}
-			if len(svctags) > 0 {
-				cfg += " tags " + strconv.Quote(strings.Join(svctags, ","))
-			}
-			if len(ropts) > 0 {
-				cfg += " opts " + strconv.Quote(strings.Join(ropts, " "))
-			}
+			if (only == "") || (only == strconv.Itoa(port)) {
+				cfg := "route add " + name + " " + route + " " + dst
+				if weight != "" {
+					cfg += " weight " + weight
+				}
+				if len(svctags) > 0 {
+					cfg += " tags " + strconv.Quote(strings.Join(svctags, ","))
+				}
+				if len(ropts) > 0 {
+					cfg += " opts " + strconv.Quote(strings.Join(ropts, " "))
+				}
 
-			config = append(config, cfg)
+				config = append(config, cfg)
+			}
 		}
 	}
 	return config


### PR DESCRIPTION
The new tag `only=` allows the user to have more granular control over which checked services
get added to the routing table.

Example:
Nomad publishes service checks for the HTTP, RPC, and Serf services to consul. Registering the tag below results in
a routing table that splits requests for nomad.service.example.com between the three different protocols.

Service Tag
```
    "urlprefix-nomad.service.example.com:443/ proto=https tlsskipverify=true"
```

Resulting Routing Table Entries
```
nomad        nomad.service.example.com:443/        https://172.16.1.8:4646        tlsskipverify=true        33%
nomad        nomad.service.example.com:443/        https://172.16.1.8:4647        tlsskipverify=true        33%
nomad        nomad.service.example.com:443/        https://172.16.1.8:4648        tlsskipverify=true        33%
```

Since we really only want to route the HTTP traffic, this commit allows you to use the rule below to only generate
a single routing table entry based on the port number associated with our HTTP port.

Service Tag
```
    "urlprefix-nomad-0.service.example.com:443/ proto=https only=4646 tlsskipverify=true"
```

Resulting Routing Table Entries
```
nomad        nomad.service.example.com:443/        https://172.16.1.8:4646        tlsskipverify=true        100.00%
```