### PR TITLE
Simple HTTP path prefix replacement

### DIFF
--- a/docs/content/cfg/_index.md
+++ b/docs/content/cfg/_index.md
@@ -29,6 +29,7 @@ Option                                     | Description
 `allow=ip:10.0.0.0/8,ip:fe80::/10`         | Restrict access to source addresses within the `10.0.0.0/8` or `fe80::/10` CIDR mask.  All other requests will be denied.
 `deny=ip:10.0.0.0/8,ip:fe80::1234`         | Deny requests that source from the `10.0.0.0/8` CIDR mask or `fe80::1234`.  All other requests will be allowed.
 `strip=/path`                              | Forward `/path/to/file` as `/to/file`
+`prepend=/prefix`                          | Forward `/path/to/file` as `/prefix/path/to/file`
 `proto=tcp`                                | Upstream service is TCP, `dst` must be `:port`
 `pxyproto=true`                            | Enables PROXY protocol on outbount TCP connection
 `proto=https`                              | Upstream service is HTTPS

--- a/docs/content/feature/_index.md
+++ b/docs/content/feature/_index.md
@@ -17,6 +17,7 @@ The following list provides a list of features supported by fabio.
  * [Metrics Support](/feature/metrics/) - support for Graphite, StatsD/DataDog and Circonus
  * [PROXY Protocol Support](/feature/proxy-protocol/) - support for HA Proxy PROXY protocol for inbound requests (use for Amazon ELB)
  * [Path Stripping](/feature/http-path-stripping/) - strip prefix paths from incoming requests
+ * [Path Prepending](/feature/path-prepending/) - prepend a prefix path on to incoming requests
  * [Server-Sent Events/SSE](/feature/sse/) - support for Server-Sent Events/SSE
  * [TCP Proxy Support](/feature/tcp-proxy/) - raw TCP proxy support
  * [TCP-SNI Proxy Support](/feature/tcp-sni-proxy/) - forward TLS connections based on hostname without re-encryption

--- a/docs/content/feature/http-path-prepending.md
+++ b/docs/content/feature/http-path-prepending.md
@@ -1,0 +1,13 @@
+---
+title: "HTTP Path Prepending"
+since: "1.5.14"
+---
+
+fabio supports prepending a path to the incoming request. If you want to
+forward `http://host/bar` as `http://host/foo/bar` you can add a `prepend=/foo`
+option to the route options as `urlprefix-/bar prepend=/foo`.
+
+Path prepending is done after path stripping. If you want to
+forward `http://host/foo/bar` as `http://host/baz/bar` you can add
+`prepend=/baz` and `strip=/foo` options to the route options as
+`urlprefix-/bar prepend=/baz strip=/foo`.

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -41,6 +41,7 @@ and you need to add a separate `urlprefix-` tag for every `host/path` prefix the
 	urlprefix-i.com/static                             # host specific path route
 	urlprefix-mysite.com/                              # host specific catch all route
 	urlprefix-/foo/bar strip=/foo                      # path stripping (forward '/bar' to upstream)
+	urlprefix-/bar prepend=/foo                        # path prepending (forward '/foo/bar' to upstream)
 	urlprefix-/foo/bar proto=https                     # HTTPS upstream
 	urlprefix-/foo/bar proto=https tlsskipverify=true  # HTTPS upstream and self-signed cert
 

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -157,6 +157,15 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if t.PrependPath != "" {
+		targetURL.Path = t.PrependPath + targetURL.Path
+		// ensure absolute path after stripping to maintain compliance with
+		// section 5.3 of RFC7230 (https://tools.ietf.org/html/rfc7230#section-5.3)
+		if !strings.HasPrefix(targetURL.Path, "/") {
+			targetURL.Path = "/" + targetURL.Path
+		}
+	}
+
 	if err := addHeaders(r, p.Config, t.StripPath); err != nil {
 		http.Error(w, "cannot parse "+r.RemoteAddr, http.StatusInternalServerError)
 		return

--- a/route/parse_new.go
+++ b/route/parse_new.go
@@ -26,6 +26,7 @@ route add <svc> <src> <dst>[ weight <w>][ tags "<t1>,<t2>,..."][ opts "k1=v1 k2=
     Valid options are:
 
 	  strip=/path        : forward '/path/to/file' as '/to/file'
+	  prepend=/prefix    : forward '/path/to/file' as '/prefix/path/to/file'
 	  proto=tcp          : upstream service is TCP, dst is ':port'
 	  proto=https        : upstream service is HTTPS
 	  tlsskipverify=true : disable TLS cert validation for HTTPS upstream

--- a/route/parse_test.go
+++ b/route/parse_test.go
@@ -205,17 +205,17 @@ func TestParseAliases(t *testing.T) {
 		// happy flows with and without aliases
 		{
 			desc: "RouteAddServiceWithoutAlias",
-			in:   `route add alpha-be alpha/ http://1.2.3.4/ opts "strip=/path proto=https"`,
+			in:   `route add alpha-be alpha/ http://1.2.3.4/ opts "strip=/path prepend=/new proto=https"`,
 			out:  []string(nil),
 		},
 		{
 			desc: "RouteAddServiceWithAlias",
-			in:   `route add alpha-be alpha/ http://1.2.3.4/ opts "strip=/path proto=https register=alpha"`,
+			in:   `route add alpha-be alpha/ http://1.2.3.4/ opts "strip=/path prepend=/new proto=https register=alpha"`,
 			out:  []string{"alpha"},
 		},
 		{
 			desc: "RouteAddServicesWithoutAliases",
-			in: `route add alpha-be alpha/ http://1.2.3.4/ opts "strip=/path proto=tcp"
+			in: `route add alpha-be alpha/ http://1.2.3.4/ opts "strip=/path prepend=/new proto=tcp"
 			route add bravo-be bravo/ http://1.2.3.5/
 			route add charlie-be charlie/ http://1.2.3.6/ opts "host=charlie"`,
 			out: []string(nil),
@@ -223,7 +223,7 @@ func TestParseAliases(t *testing.T) {
 		{
 			desc: "RouteAddServicesWithAliases",
 			in: `route add alpha-be alpha/ http://1.2.3.4/ opts "register=alpha"
-			route add bravo-be bravo/ http://1.2.3.5/ opts "strip=/foo register=bravo"
+			route add bravo-be bravo/ http://1.2.3.5/ opts "strip=/foo prepend=/new register=bravo"
 			route add charlie-be charlie/ http://1.2.3.5/ opts "host=charlie proto=https"
 			route add delta-be delta/ http://1.2.3.5/ opts "host=delta proto=https register=delta"`,
 			out: []string{"alpha", "bravo", "delta"},

--- a/route/route.go
+++ b/route/route.go
@@ -72,6 +72,7 @@ func (r *Route) addTarget(service string, targetURL *url.URL, fixedWeight float6
 
 	if opts != nil {
 		t.StripPath = opts["strip"]
+		t.PrependPath = opts["prepend"]
 		t.TLSSkipVerify = opts["tlsskipverify"] == "true"
 		t.Host = opts["host"]
 		t.ProxyProto = opts["pxyproto"] == "true"

--- a/route/target.go
+++ b/route/target.go
@@ -21,6 +21,10 @@ type Target struct {
 	// request path
 	StripPath string
 
+	// PrependPath will be added to the front of the outgoing
+	// request path (after StripPath has been removed)
+	PrependPath string
+
 	// TLSSkipVerify disables certificate validation for upstream
 	// TLS connections.
 	TLSSkipVerify bool
@@ -101,6 +105,11 @@ func (t *Target) BuildRedirectURL(requestURL *url.URL) {
 			if strings.HasPrefix(replaceRawPath, t.StripPath) {
 				replaceRawPath = replaceRawPath[len(t.StripPath):]
 			}
+		}
+		// add prepend path
+		if t.PrependPath != "" {
+			replacePath = t.PrependPath + replacePath
+			replaceRawPath = t.PrependPath + replaceRawPath
 		}
 		// do path replacement
 		t.RedirectURL.Path = strings.Replace(t.RedirectURL.Path, "$path", replacePath, 1)

--- a/route/target_test.go
+++ b/route/target_test.go
@@ -153,6 +153,26 @@ func TestTarget_BuildRedirectURL(t *testing.T) {
 				{req: "/stripme/abc/?aaa=1", want: "https://bar.com/bbb/abc/?aaa=1"},
 			},
 		},
+		{ // prepend prefix
+			route: "route add svc / http://bar.com/$path opts \"prepend=/prefix\"",
+			tests: []routeTest{
+				{req: "/", want: "http://bar.com/prefix/"},
+				{req: "/abc", want: "http://bar.com/prefix/abc"},
+				{req: "/a/b/c", want: "http://bar.com/prefix/a/b/c"},
+				{req: "/?aaa=1", want: "http://bar.com/prefix/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "http://bar.com/prefix/abc/?aaa=1"},
+			},
+		},
+		{ // strip & prepend prefix
+			route: "route add svc / http://bar.com/$path opts \"prepend=/prefix strip=/stripme\"",
+			tests: []routeTest{
+				{req: "/stripme/", want: "http://bar.com/prefix/"},
+				{req: "/stripme/abc", want: "http://bar.com/prefix/abc"},
+				{req: "/stripme/a/b/c", want: "http://bar.com/prefix/a/b/c"},
+				{req: "/stripme/?aaa=1", want: "http://bar.com/prefix/?aaa=1"},
+				{req: "/stripme/abc/?aaa=1", want: "http://bar.com/prefix/abc/?aaa=1"},
+			},
+		},
 	}
 	firstRoute := func(tbl Table) *Route {
 		for _, routes := range tbl {


### PR DESCRIPTION
This is a potential solution for #691 

A new option `prepend` is introduced. For example, `prepend=/baz` allows an incoming request with path `/bar` to be forwarded upstream with path `/baz/bar`.

Combining `prepend=/baz` with the existing `strip=/foo` option, allows an incoming request path `/foo/bar` to be forwarded upstream with path `/baz/bar`.

This change should not affect any existing functionality, and the docs are updated to match.