### PR TITLE
update version to a dev version

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ import (
 // It is also set by the linker when fabio
 // is built via the Makefile or the build/docker.sh
 // script to ensure the correct version number
-var version = "1.5.14"
+var version = "1.5.15-dev"
 
 var shuttingDown int32
 


### PR DESCRIPTION
Now that v 1.5.14 is GA, would it make sense to mark the version as a "dev" version.

_I tried to go through the Makefile, but didn't find the usual ldflag value trick usually used
to send the version string from outside_

@nathanejohnson 