### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### [v1.6.14](https://github.com/fabiolb/fabio/releases/tag/v1.5.14) - 9 Sep 2020
+### [v1.5.14](https://github.com/fabiolb/fabio/releases/tag/v1.5.14) - 9 Sep 2020
 
 
 #### Bug Fixes


### PR DESCRIPTION
This fixes a typo in the 1.5.14 release. It took me a few minutes of looking around for the docker image tag for 1.6.14 to realize that it was just a typo in the notes and not a new minor version release.