### PR TITLE
Updating the default GOGC to 100.  800 proves to be a bit insane.

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -81,7 +81,7 @@ var defaultConfig = &Config{
 		Retry:   500 * time.Millisecond,
 	},
 	Runtime: Runtime{
-		GOGC:       800,
+		GOGC:       100,
 		GOMAXPROCS: runtime.NumCPU(),
 	},
 	UI: UI{

--- a/docs/content/ref/runtime.gogc.md
+++ b/docs/content/ref/runtime.gogc.md
@@ -11,18 +11,9 @@ the value from the config file.
 Increasing this value means fewer but longer GC cycles
 since there is more garbage to collect.
 
-The default of `GOGC=100` works for Go 1.4 but shows
-a significant performance drop for Go 1.5 since the
-concurrent GC kicks in more often.
-
-During benchmarking I have found the following values
-to work for my setup and for now I consider them sane
-defaults for both Go 1.4 and Go 1.5.
-
-	GOGC=100: Go 1.5 40% slower than Go 1.4
-	GOGC=200: Go 1.5 == Go 1.4 with GOGC=100 (default)
-	GOGC=800: both Go 1.4 and 1.5 significantly faster (40%/go1.4, 100%/go1.5)
+NOTE - the default for fabio up to 1.5.14 was 800.  This changed
+to 100 in version 1.5.15
 
 The default is
 
-	runtime.gogc = 800
+	runtime.gogc = 100

--- a/fabio.properties
+++ b/fabio.properties
@@ -1184,24 +1184,12 @@
 # environment variable which also takes precedence over
 # the value from the config file.
 #
-# Increasing this value means fewer but longer GC cycles
-# since there is more garbage to collect.
-#
-# The default of GOGC=100 works for Go 1.4 but shows
-# a significant performance drop for Go 1.5 since the
-# concurrent GC kicks in more often.
-#
-# During benchmarking I have found the following values
-# to work for my setup and for now I consider them sane
-# defaults for both Go 1.4 and Go 1.5.
-#
-# GOGC=100: Go 1.5 40% slower than Go 1.4
-# GOGC=200: Go 1.5 == Go 1.4 with GOGC=100 (default)
-# GOGC=800: both Go 1.4 and 1.5 significantly faster (40%/go1.4, 100%/go1.5)
+# NOTE - the default for fabio up to 1.5.14 was 800.  This changed
+# to 100 in version 1.5.15
 #
 # The default is
 #
-# runtime.gogc = 800
+# runtime.gogc = 100
 
 
 # runtime.gomaxprocs configures GOMAXPROCS.


### PR DESCRIPTION
800% GC percentage appears to be bad default for the modern golang gargabe collector.  100%, the golang default, should still be a sane default for most people, so that is the new fabio default.