### PR TITLE
Remove golang toolchain name from release binary names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,11 @@ builds:
 
 archives:
   - id: bin
-    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Env.GOVERSION }}-{{ .Os }}_{{ .Arch }}'
+    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}_{{ .Arch }}'
     format: binary
 
 checksum:
-  name_template: '{{.ProjectName}}-{{.Version}}-{{ .Env.GOVERSION }}.sha256'
+  name_template: '{{.ProjectName}}-{{.Version}}.sha256'
 
 signs:
   -
@@ -38,6 +38,6 @@ dockers:
     dockerfile: Dockerfile-goreleaser
     image_templates:
       - 'fabiolb/fabio:latest'
-      - 'fabiolb/fabio:{{ .Version }}-{{ .Env.GOVERSION }}'
+      - 'fabiolb/fabio:{{ .Version }}'
     extra_files:
       - fabio.properties

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 		exit.Fatalf("[FATAL] %s. %s", version, err)
 	}
 	if cfg == nil {
-		fmt.Println(version)
+		fmt.Printf("%s %s\n", version, runtime.Version())
 		return
 	}
 


### PR DESCRIPTION
Add the golang runtime version to the version string when version is printed

Fixes #805