### PR TITLE
Allow Consul api to set default config for addr

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -51,8 +51,8 @@ var defaultConfig = &Config{
 	Registry: Registry{
 		Backend: "consul",
 		Consul: Consul{
-			Addr:            "localhost:8500",
-			Scheme:          "http",
+			Addr:            "",
+			Scheme:          "",
 			KVPath:          "/fabio/config",
 			NoRouteHTMLPath: "/fabio/noroute.html",
 			TagPrefix:       "urlprefix-",


### PR DESCRIPTION
As can be seen in https://github.com/hashicorp/consul/blob/91ee7990ccf27ab7fccff746f8df0df65c3c583d/api/api.go#L390 the API also defaults to localhost:8500, however it can also use the environment variable CONSUL_HTTP_ADDR which is useful when fabio is run with nomad.

This change makes sure that the existing default stays working, but it now works better by default in more situations

Fixes #773 