### PR TITLE
Do not expand the source if mapping is missing

### DIFF
--- a/registry/consul/routecmd.go
+++ b/registry/consul/routecmd.go
@@ -111,7 +111,10 @@ func parseURLPrefixTag(s, prefix string, env map[string]string) (route, opts str
 	expand := func(s string) string {
 		return os.Expand(s, func(x string) string {
 			if env == nil {
-				return ""
+				return "$" + x
+			}
+			if _, ok := env[x]; !ok {
+				return "$" + x
 			}
 			return env[x]
 		})


### PR DESCRIPTION
Do not expand the source if the key is missing.