### PR TITLE
Dockerfile: do not run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ RUN apk update && apk add --no-cache ca-certificates
 COPY --from=build /src/fabio /usr/bin
 ADD fabio.properties /etc/fabio/fabio.properties
 EXPOSE 9998 9999
+
+USER 1001
 ENTRYPOINT ["/usr/bin/fabio"]
 CMD ["-cfg", "/etc/fabio/fabio.properties"]


### PR DESCRIPTION
This switches off the warning

	************************************************************
	You are running fabio as root without the '-insecure' flag
	This will stop working with fabio 1.7!
	************************************************************

and makes all of us feel better :-)

See #369

NOTE In my limited tests it just works (using the tutorial https://learn.hashicorp.com/tutorials/nomad/load-balancing-fabio?in=nomad/load-balancing and stopping before section "Place Nomad client nodes behind AWS load balancer"), but since I am learning Nomad/Consul/Fabio, I might be missing something.

Fastest way to test:

    $ docker build -t <USER>/fabio:test-nonroot .
    $ docker push <USER>/fabio:test-nonroot

job spec:

    task "fabio" {
      driver = "docker"
      config {
        image        = "<USER>/fabio:test-nonroot"


