### PR TITLE
Fix x-forwarded-for header processing for ws connections

### DIFF
--- a/proxy/http_headers.go
+++ b/proxy/http_headers.go
@@ -58,7 +58,12 @@ func addHeaders(r *http.Request, cfg config.Proxy, stripPath string) error {
 	// http proxy which sets it.
 	ws := r.Header.Get("Upgrade") == "websocket"
 	if ws {
-		r.Header.Set("X-Forwarded-For", remoteIP)
+		targetHeader := []string{remoteIP}
+		sourceHeader := r.Header.Get("X-Forwarded-For")
+		if sourceHeader != "" {
+			targetHeader = append([]string{sourceHeader}, targetHeader...)
+		}
+		r.Header.Set("X-Forwarded-For", strings.Join(targetHeader, ","))
 	}
 
 	// Issue #133: Setting the X-Forwarded-Proto header to


### PR DESCRIPTION
Fix `x-forwarded-for` header processing logic for ws connections.
Instead of simply use remoteIP as `x-forwarded-for` header for backend, server add remoteIP to the end of `x-forwarded-for` header from client and send result to backend.

This PR possibly connected with issue https://github.com/fabiolb/fabio/issues/828