### PR TITLE
Add IdleConnTimeout configurable for http transport

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type Proxy struct {
 	DialTimeout           time.Duration
 	ResponseHeaderTimeout time.Duration
 	KeepAliveTimeout      time.Duration
+	IdleConnTimeout       time.Duration
 	FlushInterval         time.Duration
 	GlobalFlushInterval   time.Duration
 	LocalIP               string

--- a/config/default.go
+++ b/config/default.go
@@ -47,6 +47,7 @@ var defaultConfig = &Config{
 		GlobalFlushInterval: 0,
 		LocalIP:             LocalIPString(),
 		AuthSchemes:         map[string]AuthScheme{},
+		IdleConnTimeout:     15 * time.Second,
 	},
 	Registry: Registry{
 		Backend: "consul",

--- a/config/load.go
+++ b/config/load.go
@@ -129,6 +129,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.DurationVar(&cfg.Proxy.DialTimeout, "proxy.dialtimeout", defaultConfig.Proxy.DialTimeout, "connection timeout for backend connections")
 	f.DurationVar(&cfg.Proxy.ResponseHeaderTimeout, "proxy.responseheadertimeout", defaultConfig.Proxy.ResponseHeaderTimeout, "response header timeout")
 	f.DurationVar(&cfg.Proxy.KeepAliveTimeout, "proxy.keepalivetimeout", defaultConfig.Proxy.KeepAliveTimeout, "keep-alive timeout")
+	f.DurationVar(&cfg.Proxy.IdleConnTimeout, "proxy.idleconntimeout", defaultConfig.Proxy.IdleConnTimeout, "idle timeout, when to close (keep-alive) connections")
 	f.StringVar(&cfg.Proxy.LocalIP, "proxy.localip", defaultConfig.Proxy.LocalIP, "fabio address in Forward headers")
 	f.StringVar(&cfg.Proxy.ClientIPHeader, "proxy.header.clientip", defaultConfig.Proxy.ClientIPHeader, "header for the request ip")
 	f.StringVar(&cfg.Proxy.TLSHeader, "proxy.header.tls", defaultConfig.Proxy.TLSHeader, "header for TLS connections")

--- a/main.go
+++ b/main.go
@@ -213,6 +213,7 @@ func newHTTPProxy(cfg *config.Config) http.Handler {
 	newTransport := func(tlscfg *tls.Config) *http.Transport {
 		return &http.Transport{
 			ResponseHeaderTimeout: cfg.Proxy.ResponseHeaderTimeout,
+			IdleConnTimeout: cfg.Proxy.IdleConnTimeout,
 			MaxIdleConnsPerHost:   cfg.Proxy.MaxConn,
 			Dial: (&net.Dialer{
 				Timeout:   cfg.Proxy.DialTimeout,


### PR DESCRIPTION
Please see this issue for additional context https://github.com/fabiolb/fabio/issues/862.

I set a default value for `IdleConnTimeout` of 15s, because the `KeepAliveTimeout` default is 0s and `net.Dialer` will make it into a 15s default if it's 0s.

Thank you for reviewing.