### PR TITLE
update go and alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine AS build
+FROM golang:1.17.8-alpine AS build
 
 ARG consul_version=1.8.2
 ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip /usr/local/bin
@@ -13,7 +13,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -mod=vendor -trimpath -ldflags "-s -w" ./...
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -trimpath -ldflags "-s -w"
 
-FROM alpine:3.12
+FROM alpine:3.15
 RUN apk update && apk add --no-cache ca-certificates
 COPY --from=build /src/fabio /usr/bin
 ADD fabio.properties /etc/fabio/fabio.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.8-alpine AS build
+FROM golang:1.18-alpine3.15 AS build
 
 ARG consul_version=1.8.2
 ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip /usr/local/bin


### PR DESCRIPTION
There are many CVEs on the current alpine and golang version.
I have updated both and tested it on my local environment, it seems to have no effect on Fabio's functionality.