### PR TITLE
Build multi-arch Docker images for amd64 and arm64 architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,10 +31,44 @@ signs:
     artifacts: checksum
 
 dockers:
-  -
-    dockerfile: Dockerfile-goreleaser
+  - dockerfile: Dockerfile-goreleaser
+    use: buildx
+    goos: linux
+    goarch: amd64
     image_templates:
-      - 'fabiolb/fabio:latest'
-      - 'fabiolb/fabio:{{ .Version }}'
+      - 'fabiolb/fabio:latest-amd64'
+      - 'fabiolb/fabio:{{ .Version }}-amd64'
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
     extra_files:
       - fabio.properties
+      
+  - dockerfile: Dockerfile-goreleaser
+    use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - 'fabiolb/fabio:latest-arm64v8'
+      - 'fabiolb/fabio:{{ .Version }}-arm64v8'
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    extra_files:
+      - fabio.properties
+
+docker_manifests:
+  - name_template: 'fabiolb/fabio:latest'
+    image_templates:
+      - 'fabiolb/fabio:latest-amd64'
+      - 'fabiolb/fabio:latest-arm64v8'
+  - name_template: 'fabiolb/fabio:{{ .Version }}'
+    image_templates:
+      - 'fabiolb/fabio:{{ .Version }}-amd64'
+      - 'fabiolb/fabio:{{ .Version }}-arm64v8'


### PR DESCRIPTION
This PR updates GoRelaser config to build multi-architecture Docker images using `buildx`. Currently, this change builds amd64 and arm64v8 images. 

Note that this change _may_ break release scripts if buildx is not available on the host machines during release. 

Images built with this configuration are available on my personal [Docker hub](https://hub.docker.com/r/vamc19/fabio/tags)

Fixes #833 