### PR TITLE
Documented preflight policy path (fixes  #876)

### DIFF
--- a/docs/content/feature/certificate-stores.md
+++ b/docs/content/feature/certificate-stores.md
@@ -192,6 +192,11 @@ certificates are stored, for example:
       path "secret/fabio/cert/*" {
         capabilities = ["read"]
       }
+      
+      #to check for kv version in newer vault instances
+      path "sys/internal/ui/mounts/secret/fabio/certs" {
+        capabilities = ["read"]
+      }
 
 ##### Example
 


### PR DESCRIPTION
Added section describing that newer versions of vault need the preflight check path to be readable.