### PR TITLE
updated the custom css file

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -32,3 +32,26 @@ p.since::before {
 p.since {
 	font-size: 16px;
 }
+
+/* adjustment to code example sections so they are more readable */
+pre[class*="language"], pre code[class*="language"] {
+	text-shadow: none;
+	color: #808080;
+}
+pre code .token.operator, pre code[class*="operator"] {
+	background: inherit;
+}
+.clipboard-copy {
+	top: 6px !important;
+	right: 8px;
+	color: #808080;
+	background-color: transparent;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	font-weight: 600;
+	opacity: 1;
+	padding: 2px 5px;
+}
+pre .language-name {
+	right: 75px;
+}


### PR DESCRIPTION
theme is a bootstrap from called theDocs, don't know where the licesnse is to update the theme but its several years outdated
added section in the custom css that fixes the odd text shadow, this didn't fix the odd highlight of colons(changed that), and the odd low contrast of the word float (fixed)
also adjusted the copy button on text areas, this was hidden in most sections as the text was only one line and the position of absolute and positioning would push it further down the section, now it is apparent all the time no matter what