### PR TITLE
setting sni to match host

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/fabiolb/fabio/transport"
 	gkm "github.com/go-kit/kit/metrics"
 	"io"
 	"log"
@@ -67,6 +68,8 @@ func main() {
 		fmt.Printf("%s %s\n", version, runtime.Version())
 		return
 	}
+
+	transport.SetConfig(cfg)
 
 	log.Printf("[INFO] Setting log level to %s", logOutput.Level())
 	if !logOutput.SetLevel(cfg.Log.Level) {
@@ -208,19 +211,6 @@ func newHTTPProxy(cfg *config.Config, statsHandler *proxy.HttpStatsHandler) *pro
 	log.Printf("[INFO] Using routing strategy %q", cfg.Proxy.Strategy)
 	log.Printf("[INFO] Using route matching %q", cfg.Proxy.Matcher)
 
-	newTransport := func(tlscfg *tls.Config) *http.Transport {
-		return &http.Transport{
-			ResponseHeaderTimeout: cfg.Proxy.ResponseHeaderTimeout,
-			IdleConnTimeout:       cfg.Proxy.IdleConnTimeout,
-			MaxIdleConnsPerHost:   cfg.Proxy.MaxConn,
-			Dial: (&net.Dialer{
-				Timeout:   cfg.Proxy.DialTimeout,
-				KeepAlive: cfg.Proxy.KeepAliveTimeout,
-			}).Dial,
-			TLSClientConfig: tlscfg,
-		}
-	}
-
 	authSchemes, err := auth.LoadAuthSchemes(cfg.Proxy.AuthSchemes)
 
 	if err != nil {
@@ -229,8 +219,8 @@ func newHTTPProxy(cfg *config.Config, statsHandler *proxy.HttpStatsHandler) *pro
 
 	return &proxy.HTTPProxy{
 		Config:            cfg.Proxy,
-		Transport:         newTransport(nil),
-		InsecureTransport: newTransport(&tls.Config{InsecureSkipVerify: true}),
+		Transport:         transport.NewTransport(nil),
+		InsecureTransport: transport.NewTransport(&tls.Config{InsecureSkipVerify: true}),
 		Lookup: func(r *http.Request) *route.Target {
 			t := route.GetTable().Lookup(r, r.Header.Get("trace"), pick, match, globCache, cfg.GlobMatchingDisabled)
 			if t == nil {

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -193,9 +193,11 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	trace.InjectHeaders(span, r)
 
 	upgrade, accept := r.Header.Get("Upgrade"), r.Header.Get("Accept")
-
+	
 	tr := p.Transport
-	if t.TLSSkipVerify {
+	if t.Transport != nil {
+		tr = t.Transport
+	} else if t.TLSSkipVerify {
 		tr = p.InsecureTransport
 	}
 

--- a/route/route.go
+++ b/route/route.go
@@ -1,7 +1,9 @@
 package route
 
 import (
+	"crypto/tls"
 	"fmt"
+	"github.com/fabiolb/fabio/transport"
 	"log"
 	"net/url"
 	"reflect"
@@ -66,11 +68,16 @@ func (r *Route) addTarget(service string, targetURL *url.URL, fixedWeight float6
 
 	var err error
 	if opts != nil {
+
 		t.StripPath = opts["strip"]
 		t.PrependPath = opts["prepend"]
 		t.TLSSkipVerify = opts["tlsskipverify"] == "true"
 		t.Host = opts["host"]
 		t.ProxyProto = opts["pxyproto"] == "true"
+
+		if t.Host != "" && (t.URL.Scheme == "https" || opts["proto"] == "https") {
+			t.Transport = transport.NewTransport(&tls.Config{ServerName: t.Host, InsecureSkipVerify: t.TLSSkipVerify})
+		}
 
 		if opts["redirect"] != "" {
 			t.RedirectCode, err = strconv.Atoi(opts["redirect"])

--- a/route/target.go
+++ b/route/target.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	gkm "github.com/go-kit/kit/metrics"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -67,6 +68,9 @@ type Target struct {
 
 	// ProxyProto enables PROXY Protocol on upstream connection
 	ProxyProto bool
+
+	// Transport allows for different types of transports
+	Transport *http.Transport
 }
 
 func (t *Target) BuildRedirectURL(requestURL *url.URL) {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,0 +1,29 @@
+package transport
+
+import (
+	"crypto/tls"
+	"github.com/fabiolb/fabio/config"
+	"net"
+	"net/http"
+)
+
+var (
+	cfg *config.Config = &config.Config{}
+)
+
+func NewTransport(tlscfg *tls.Config) *http.Transport {
+	return &http.Transport{
+		ResponseHeaderTimeout: cfg.Proxy.ResponseHeaderTimeout,
+		IdleConnTimeout:       cfg.Proxy.IdleConnTimeout,
+		MaxIdleConnsPerHost:   cfg.Proxy.MaxConn,
+		Dial: (&net.Dialer{
+			Timeout:   cfg.Proxy.DialTimeout,
+			KeepAlive: cfg.Proxy.KeepAliveTimeout,
+		}).Dial,
+		TLSClientConfig: tlscfg,
+	}
+}
+
+func SetConfig(cfg *config.Config) {
+	cfg = cfg
+}


### PR DESCRIPTION
fixes #850
if host is present on the route, and proto is https, then set sni name to match host