### PR TITLE
Add additional clean function for prometheus metric names

### DIFF
--- a/metrics/names.go
+++ b/metrics/names.go
@@ -72,7 +72,8 @@ func Labels(labels, values []string, stringsprefix, fieldsep, recsep string) str
 // parseNames parses the route metric name template.
 func parseNames(tmpl string) (*template.Template, error) {
 	funcMap := template.FuncMap{
-		"clean": clean,
+		"clean":      clean,
+		"clean_prom": clean_prom,
 	}
 	t, err := template.New("names").Funcs(funcMap).Parse(tmpl)
 	if err != nil {
@@ -124,6 +125,18 @@ func clean(s string) string {
 	}
 	s = strings.Replace(s, ".", "_", -1)
 	s = strings.Replace(s, ":", "_", -1)
+	return strings.ToLower(s)
+}
+
+// clean_prom creates safe names for prometheus reporting by replacing
+// some characters with underscores.
+func clean_prom(s string) string {
+	if s == "" {
+		return "_"
+	}
+	s = strings.Replace(s, ".", "_", -1)
+	s = strings.Replace(s, ":", "_", -1)
+	s = strings.Replace(s, "-", "_", -1)
 	return strings.ToLower(s)
 }
 

--- a/metrics/provider_prometheus.go
+++ b/metrics/provider_prometheus.go
@@ -12,9 +12,9 @@ type PromProvider struct {
 }
 
 func NewPromProvider(namespace, subsystem string, buckets []float64) Provider {
-	namespace = clean_prom(namespace)
+	namespace = clean(namespace)
 	if len(subsystem) > 0 {
-		subsystem = clean_prom(subsystem)
+		subsystem = clean(subsystem)
 	}
 	return &PromProvider{
 		Opts: promclient.Opts{

--- a/metrics/provider_prometheus.go
+++ b/metrics/provider_prometheus.go
@@ -12,9 +12,9 @@ type PromProvider struct {
 }
 
 func NewPromProvider(namespace, subsystem string, buckets []float64) Provider {
-	namespace = clean(namespace)
+	namespace = clean_prom(namespace)
 	if len(subsystem) > 0 {
-		subsystem = clean(subsystem)
+		subsystem = clean_prom(subsystem)
 	}
 	return &PromProvider{
 		Opts: promclient.Opts{
@@ -27,13 +27,13 @@ func NewPromProvider(namespace, subsystem string, buckets []float64) Provider {
 
 func (p *PromProvider) NewCounter(name string, labels ...string) gkm.Counter {
 	copts := promclient.CounterOpts(p.Opts)
-	copts.Name = clean(name)
+	copts.Name = clean_prom(name)
 	return prommetrics.NewCounterFrom(copts, labels)
 }
 
 func (p *PromProvider) NewGauge(name string, labels ...string) gkm.Gauge {
 	gopts := promclient.GaugeOpts(p.Opts)
-	gopts.Name = clean(name)
+	gopts.Name = clean_prom(name)
 	return prommetrics.NewGaugeFrom(gopts, labels)
 }
 
@@ -41,7 +41,7 @@ func (p *PromProvider) NewHistogram(name string, labels ...string) gkm.Histogram
 	hopts := promclient.HistogramOpts{
 		Namespace:   p.Opts.Namespace,
 		Subsystem:   p.Opts.Subsystem,
-		Name:        clean(name),
+		Name:        clean_prom(name),
 		Help:        p.Opts.Help,
 		ConstLabels: p.Opts.ConstLabels,
 		Buckets:     p.Buckets,


### PR DESCRIPTION
Issue description

With hostnames having dash in name and fabio using prometheus metrics, I'm running into the issue like:

```
2022/08/24 21:21:47 [INFO] Registering metrics provider "prometheus"
panic: descriptor Desc{fqName: "vol-client-1_fabio_route", help: "", constLabels: {}, variableLabels: [service host path target]} is invalid: "vol-client-1_fabio_route" is not a valid metric name

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc00
```

It is indeed invalid metric name as there is `-` in metric name which is not allowed.

With this PR there is another function added alongside `clean` called `clean_prom` and used in prometheus provider.
Other option would be changing `clean` function directly but that can break the existing environment with the upgrade.
Therefore, adding additional function is safer.
If this approach is fine - I'll update documentation as well, but first want to get feedback if I'm missing something or this approach is too simple to solve the issue

```
