### PR TITLE
Change the shutdown procedure to deregister fabio from all registries and then shutdown the proxy

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type Proxy struct {
 	NoRouteStatus         int
 	MaxConn               int
 	ShutdownWait          time.Duration
+	DeregisterGracePeriod time.Duration
 	DialTimeout           time.Duration
 	ResponseHeaderTimeout time.Duration
 	KeepAliveTimeout      time.Duration

--- a/config/load.go
+++ b/config/load.go
@@ -138,6 +138,7 @@ func load(cmdline, environ, envprefix []string, props *properties.Properties) (c
 	f.StringVar(&cfg.Proxy.Matcher, "proxy.matcher", defaultConfig.Proxy.Matcher, "path matching algorithm")
 	f.IntVar(&cfg.Proxy.NoRouteStatus, "proxy.noroutestatus", defaultConfig.Proxy.NoRouteStatus, "status code for invalid route. Must be three digits")
 	f.DurationVar(&cfg.Proxy.ShutdownWait, "proxy.shutdownwait", defaultConfig.Proxy.ShutdownWait, "time for graceful shutdown")
+	f.DurationVar(&cfg.Proxy.DeregisterGracePeriod, "proxy.deregistergraceperiod", defaultConfig.Proxy.DeregisterGracePeriod, "time to wait after deregistering from a registry")
 	f.DurationVar(&cfg.Proxy.DialTimeout, "proxy.dialtimeout", defaultConfig.Proxy.DialTimeout, "connection timeout for backend connections")
 	f.DurationVar(&cfg.Proxy.ResponseHeaderTimeout, "proxy.responseheadertimeout", defaultConfig.Proxy.ResponseHeaderTimeout, "response header timeout")
 	f.DurationVar(&cfg.Proxy.KeepAliveTimeout, "proxy.keepalivetimeout", defaultConfig.Proxy.KeepAliveTimeout, "keep-alive timeout")

--- a/main.go
+++ b/main.go
@@ -114,14 +114,14 @@ func main() {
 
 	exit.Listen(func(s os.Signal) {
 		atomic.StoreInt32(&shuttingDown, 1)
+		if registry.Default != nil {
+			registry.Default.DeregisterAll()
+		}
+		time.Sleep(cfg.Proxy.DeregisterGracePeriod)
 		proxy.Shutdown(cfg.Proxy.ShutdownWait)
 		if prof != nil {
 			prof.Stop()
 		}
-		if registry.Default == nil {
-			return
-		}
-		registry.Default.DeregisterAll()
 	})
 
 	metrics, err := metrics.Initialize(&cfg.Metrics)


### PR DESCRIPTION
The current shutdown procedure shuts down all proxies and then de-registers Fabio from the service registry. This may cause some requests to fail while a Fabio instance is shutting down. This PR reverses the order and introduces a de-register grace period, causing Fabio to wait for a configurable period after de-registering from a registry and then shutting down the proxies. This way no new requests will be sent to the stopping instances, while giving time to running requests to finish.