### PR TITLE
[Docs] Fix wrong parameter name

### DIFF
--- a/docs/content/feature/tcp-proxy.md
+++ b/docs/content/feature/tcp-proxy.md
@@ -15,6 +15,6 @@ fabio -proxy.addr ':1234;proto=tcp'
 TCP proxy support can be combined with [Certificate Stores](/feature/certificate-stores/) to provide TLS termination on fabio.
 
 ```
-fabio -proxy.cs 'cs=ssl;type=path;path=/etc/ssl' -proxy.addr ':1234;proto=tcp;cs=ssl'
+fabio -proxy.cs 'cs=ssl;type=path;cert=/etc/ssl' -proxy.addr ':1234;proto=tcp;cs=ssl'
 ```
 


### PR DESCRIPTION
Starting fabio with `path` here results in an error which asks for a parameter `cert` so I guess that name changed since writing this doc