### PR TITLE
Consul registry performance improvements

### DIFF
--- a/registry/consul/passing.go
+++ b/registry/consul/passing.go
@@ -7,28 +7,48 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
+// passingServices takes a list of Consul Health Checks and only returns ones where the overall health of
+// the Service Instance is passing. This includes the health of the Node that the Services Instance runs on.
 func passingServices(checks []*api.HealthCheck, status []string, strict bool) []*api.HealthCheck {
 	var p []*api.HealthCheck
+
+CHECKS:
 	for _, svc := range checks {
 		if !isServiceCheck(svc) {
 			continue
 		}
-		total, passing := countChecks(svc, checks, status)
+		var total, passing int
+
+		for _, c := range checks {
+			if svc.Node == c.Node {
+				if svc.ServiceID == c.ServiceID {
+					total++
+					if hasStatus(c, status) {
+						passing++
+					}
+				}
+				if c.CheckID == "serfHealth" && c.Status == "critical" {
+					log.Printf("[DEBUG] consul: Skipping service %q since agent on node %q is down: %s", c.ServiceID, c.Node, c.Output)
+					continue CHECKS
+				}
+				if c.CheckID == "_node_maintenance" {
+					log.Printf("[DEBUG] consul: Skipping service %q since node %q is in maintenance mode: %s", c.ServiceID, c.Node, c.Output)
+					continue CHECKS
+				}
+				if c.CheckID == "_service_maintenance:"+svc.ServiceID && c.Status == "critical" {
+					log.Printf("[DEBUG] consul: Skipping service %q since it is in maintenance mode: %s", svc.ServiceID, c.Output)
+					continue CHECKS
+				}
+			}
+		}
+
 		if passing == 0 {
 			continue
 		}
 		if strict && total != passing {
 			continue
 		}
-		if isAgentCritical(svc, checks) {
-			continue
-		}
-		if isNodeInMaintenance(svc, checks) {
-			continue
-		}
-		if isServiceInMaintenance(svc, checks) {
-			continue
-		}
+
 		p = append(p, svc)
 	}
 
@@ -41,56 +61,6 @@ func isServiceCheck(c *api.HealthCheck) bool {
 		c.CheckID != "serfHealth" &&
 		c.CheckID != "_node_maintenance" &&
 		!strings.HasPrefix(c.CheckID, "_service_maintenance:")
-}
-
-// isAgentCritical returns true if the agent on the node on which the service
-// runs is critical.
-func isAgentCritical(svc *api.HealthCheck, checks []*api.HealthCheck) bool {
-	for _, c := range checks {
-		if svc.Node == c.Node && c.CheckID == "serfHealth" && c.Status == "critical" {
-			log.Printf("[DEBUG] consul: Skipping service %q since agent on node %q is down: %s", c.ServiceID, c.Node, c.Output)
-			return true
-		}
-	}
-	return false
-}
-
-// isNodeInMaintenance returns true if the node on which the service runs is in
-// maintenance mode.
-func isNodeInMaintenance(svc *api.HealthCheck, checks []*api.HealthCheck) bool {
-	for _, c := range checks {
-		if svc.Node == c.Node && c.CheckID == "_node_maintenance" {
-			log.Printf("[DEBUG] consul: Skipping service %q since node %q is in maintenance mode: %s", c.ServiceID, c.Node, c.Output)
-			return true
-		}
-	}
-	return false
-}
-
-// isServiceInMaintenance returns true if the service instance is in
-// maintenance mode.
-func isServiceInMaintenance(svc *api.HealthCheck, checks []*api.HealthCheck) bool {
-	for _, c := range checks {
-		if svc.Node == c.Node && c.CheckID == "_service_maintenance:"+svc.ServiceID && c.Status == "critical" {
-			log.Printf("[DEBUG] consul: Skipping service %q since it is in maintenance mode: %s", svc.ServiceID, c.Output)
-			return true
-		}
-	}
-	return false
-}
-
-// countChecks counts the number of service checks exist for a given service
-// and how many of them are passing.
-func countChecks(svc *api.HealthCheck, checks []*api.HealthCheck, status []string) (total int, passing int) {
-	for _, c := range checks {
-		if svc.Node == c.Node && svc.ServiceID == c.ServiceID {
-			total++
-			if hasStatus(c, status) {
-				passing++
-			}
-		}
-	}
-	return
 }
 
 // hasStatus returns true if the health check status is one of the given


### PR DESCRIPTION
Hi, it's me again trying to improve route update performance for our absurd number of routes. 😁

There's two major changes here:

The first is adding "filtering" so that only Consul Health Checks with the applicable Service Tag Prefix (and serf/maintenance checks) are considered during the rest of the process. In our Production environments this brings down the number of checks that Fabio has to look at from ~40k down to ~12k.

The second change is simplifying the `passingServices` function from an $O(n^5)$ process to $O(n^2)$. Each of the "helper" functions (`countChecks` `isAgentCritical` `isNodeInMaintenance` `isServiceInMaintenance`) did their own loop over each of the Consul Health Checks which added up in time very quickly.

Both of these changes drastically reduced the amount of time spent processing responses from Consul. In a test using real Consul data but not serving traffic we saw a reduction from around 90 seconds to less than 10 seconds. We've been testing Fabio with these changes in a non-production environment for about a week now, and have not detected any issues.
![image](https://user-images.githubusercontent.com/82290/227013074-767dfc3e-90db-4973-915e-31c32227b371.png)
(The increase in `makeConfig` shown on the graph is due to how I measured it. It includes time waiting to write on the channel back to the main Fabio goroutine. This wasn't an issue before because processing the Consul data took longer than the time needed to build the actual route table (~10s) but the scales have now flipped. Building the Route Table takes longer than processing the data from Consul.)

I also had profiling running during my tests. Here's stock Fabio:
![Stock Fabio CPU profile](https://user-images.githubusercontent.com/82290/227013546-261791b4-1ea6-44df-882b-59bb3f193a47.png)

After adding the Check "filtering":
![Consul Health Check filtering CPU profile](https://user-images.githubusercontent.com/82290/227013754-c8182057-cc23-497c-8bcd-ff72b4308672.png)

After simplifying `passingServices`:
![Filtering plus simplified passingServices](https://user-images.githubusercontent.com/82290/227013671-3868501a-2105-42c1-8334-a3ccd1c71378.png)

I'm very interested in any feedback about these changes and will do what I can to help satisfy any concerns. Thanks!