### PR TITLE
Dockerfile: add CAP_NET_BIND_SERVICE+eip to fabio to allow running as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN setcap cap_net_bind_service=+ep /src/fabio
 FROM alpine:3.16
 RUN apk update && apk add --no-cache ca-certificates
 COPY --from=build /src/fabio /usr/bin
-ADD fabio.properties /etc/fabio/fabio.properties
+COPY --chown=nobody:nogroup fabio.properties /etc/fabio/fabio.properties
+USER nobody:nogroup
 EXPOSE 9998 9999
 ENTRYPOINT ["/usr/bin/fabio"]
 CMD ["-cfg", "/etc/fabio/fabio.properties"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@ ARG vault_version=1.11.0
 ADD https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_amd64.zip /usr/local/bin
 RUN cd /usr/local/bin && unzip vault_${vault_version}_linux_amd64.zip
 
-RUN apk update && apk add --no-cache git
+RUN apk update && apk add --no-cache git libcap
 WORKDIR /src
 COPY . .
 RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -trimpath -ldflags "-s -w" ./...
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w"
+RUN setcap cap_net_bind_service=+ep /src/fabio
 
 FROM alpine:3.16
 RUN apk update && apk add --no-cache ca-certificates


### PR DESCRIPTION
Without the change, the following fails:

```
$ docker build -t myfabio . && docker run -e CONSUL_HTTP_ADDR=$CONSUL_HTTP_ADDR -e CONSUL_HTTP_AUTH=$CONSUL_HTTP_AUTH --rm -u nobody:nobody --network=host myfabio -registry.consul.addr=http://192.168.40.1:8500 -proxy.addr=0.0.0.0:80
[+] Building 37.2s (23/23) FINISHED                                                                                        docker:default
.....
2023/09/07 09:52:45 [FATAL] listen: Fail to listen. listen tcp 0.0.0.0:80: bind: permission denied
.....
```

After the change, it works. This is the only change needed to run fabio as non-root. System administrator can choose the user with docker options.

Related: https://github.com/fabiolb/fabio/issues/369 https://github.com/marco-m/fabio/commit/c0391d25f2aa29aa4697765c4d4c847d33d6ad6e https://github.com/fabiolb/fabio/pull/851