### PR TITLE
Update Github runner image.

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
       with:


### PR DESCRIPTION
The 18.04 runner was deprecated some time ago.
[GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)