### PR TITLE
Update and try fix GH Pages publish action.

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -9,7 +9,7 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: build

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -17,8 +17,8 @@ jobs:
         export PATH=${PATH}:${HOME}/bin
         make github-pages
     - name: deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        github_token: ${{ secrets.GH_ACTIONS_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/public
         cname: fabiolb.net


### PR DESCRIPTION
from the latest version of the [gh-pages docs](https://github.com/peaceiris/actions-gh-pages/blob/main/README.md#%EF%B8%8F-set-runners-access-token-github_token) it should use GITHUB_TOKEN to authenticate...