### PR TITLE
go-kit/kit/log go-kit/log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f
 	github.com/circonus-labs/circonus-gometrics/v3 v3.4.7
 	github.com/go-kit/kit v0.13.0
+	github.com/go-kit/log v0.2.1
 	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/consul/api v1.29.4
 	github.com/hashicorp/go-multierror v1.1.1
@@ -51,7 +52,6 @@ require (
 	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/metrics/provider_dogstatsd.go
+++ b/metrics/provider_dogstatsd.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/go-kit/kit/log"
 	gkm "github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/dogstatsd"
+	"github.com/go-kit/log"
 )
 
 type DogstatsdProvider struct {


### PR DESCRIPTION
Small PR to fix `"github.com/go-kit/kit/log" is deprecated: Use github.com/go-kit/log instead. (SA1019)`

This can easily wait until after 1.6.4 release.