### PR TITLE
Report all certificate errors instead of stopping at the first. (#941)

### DIFF
--- a/bgp/bgp_nonwindows_test.go
+++ b/bgp/bgp_nonwindows_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package bgp

--- a/cert/load_test.go
+++ b/cert/load_test.go
@@ -42,7 +42,7 @@ func TestReplaceSuffix(t *testing.T) {
 func TestUpgradeCACertificate(t *testing.T) {
 	// generated at
 	// https://eu-west-1.console.aws.amazon.com/apigateway/home?region=eu-west-1#/client-certificates
-	const awsApiGWCert = `
+	const awsAPIGWCert = `
 -----BEGIN CERTIFICATE-----
 MIIC6DCCAdCgAwIBAgIIZAgycYqDRqQwDQYJKoZIhvcNAQELBQAwNDELMAkGA1UE
 BhMCVVMxEDAOBgNVBAcTB1NlYXR0bGUxEzARBgNVBAMTCkFwaUdhdGV3YXkwHhcN
@@ -62,7 +62,7 @@ kqBgtRrHux3BRxPRqS4jM4akdplFhejHExVatOxfS+DEXzFefi+aMb7qApB1YjV/
 n/iFVG4Y6zyXQY2RzTt+ZB2VPR72X4wqS9fBeQ==
 -----END CERTIFICATE-----`
 
-	p, rest := pem.Decode([]byte(awsApiGWCert))
+	p, rest := pem.Decode([]byte(awsAPIGWCert))
 	if len(rest) > 0 {
 		t.Fatal("want only one cert")
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/consul/api v1.29.4
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-sockaddr v1.0.7
 	github.com/hashicorp/vault/api v1.15.0
 	github.com/hashicorp/vault/sdk v0.14.0
@@ -61,6 +60,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8 // indirect


### PR DESCRIPTION
changed the loading of certificates process to report all errors found.

```
2025/01/23 22:44:34 [ERROR] cert: Failed to load certificates. 4 errors occurred:
	* cert: cannot load certificate nomad.service.consul-key.pem
	* cert: invalid certificate fabio.service.consul-cert.pem. tls: failed to find any PEM data in key input
	* cert: invalid certificate fabio.service.consul-key.pem. tls: failed to find any PEM data in key input
	* cert: cannot load certificate consul.service.consul-cert.pem
```

These errors reported were a result of deleting the nomad-cert, consul-key and uploading garbage to fabio-key.