### PR TITLE
update CI components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.23-alpine3.20 AS build
 
-ARG consul_version=1.19.2
+ARG consul_version=1.20.2
 ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip /usr/local/bin
 RUN cd /usr/local/bin && unzip consul_${consul_version}_linux_amd64.zip
 
-ARG vault_version=1.17.5
+ARG vault_version=1.18.4
 ADD https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_amd64.zip /usr/local/bin
 RUN cd /usr/local/bin && unzip vault_${vault_version}_linux_amd64.zip
 

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ GOVERSION ?= $(shell go version | awk '{print $$3;}')
 GORELEASER ?= $(shell which goreleaser)
 
 # pin versions for CI builds
-CI_CONSUL_VERSION ?= 1.19.2
-CI_VAULT_VERSION ?= 1.17.5
-CI_HUGO_VERSION ?= 0.101.0
-CI_GOBGP_VERSION ?= 3.29.0
+CI_CONSUL_VERSION ?= 1.20.2
+CI_VAULT_VERSION ?= 1.18.4
+CI_HUGO_VERSION ?= 0.142.0
+CI_GOBGP_VERSION ?= 3.33.0
 
 BETA_OSES = linux darwin
 


### PR DESCRIPTION
Update CI component version:

- Consul to 1.20.2
- Vault to 1.18.4
- Hugo to 0.142.0
- GoBGP to 3.33.0