### PR TITLE
Add a golang-linter to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
           version: v1.64.5
   build:
     runs-on: ubuntu-latest
+    needs: [ "golangci" ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,18 @@
 on: [push, pull_request]
 name: Build
 jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.5
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+run:
+  timeout: 10m
+  concurrency: 4
+  allow-parallel-runners: true
+  allow-serial-runners: true
+linters:
+  disable-all: true
+  enable:
+    - asciicheck

--- a/logger/pattern.go
+++ b/logger/pattern.go
@@ -123,17 +123,17 @@ var fields = map[string]field{
 	},
 	"$response_time_ms": func(b *bytes.Buffer, e *Event) {
 		d := e.End.Sub(e.Start).Nanoseconds()
-		s, µs := d/int64(time.Second), d%int64(time.Second)/int64(time.Millisecond)
+		s, us := d/int64(time.Second), d%int64(time.Second)/int64(time.Millisecond)
 		atoi(b, s, 0)
 		b.WriteRune('.')
-		atoi(b, µs, 3)
+		atoi(b, us, 3)
 	},
 	"$response_time_us": func(b *bytes.Buffer, e *Event) {
 		d := e.End.Sub(e.Start).Nanoseconds()
-		s, µs := d/int64(time.Second), d%int64(time.Second)/int64(time.Microsecond)
+		s, us := d/int64(time.Second), d%int64(time.Second)/int64(time.Microsecond)
 		atoi(b, s, 0)
 		b.WriteRune('.')
-		atoi(b, µs, 6)
+		atoi(b, us, 6)
 	},
 	"$response_time_ns": func(b *bytes.Buffer, e *Event) {
 		d := e.End.Sub(e.Start).Nanoseconds()


### PR DESCRIPTION
Add a golangci-lint (https://github.com/golangci/golangci-lint) into CI. 

Currently, as a first stage, enable only one linter (nonascii symbols) and fix error into code. 

In a next stages, I will enable a part of linters and fix errors.