### PR TITLE
Update for deprecated goreleaser config.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,8 @@ builds:
 archives:
   - id: bin
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}_{{ .Arch }}'
-    format: binary
+    formats:
+      - binary
 source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{.Version }}.src'


### PR DESCRIPTION
During the last release I saw a warning about a deprecation for "format" in favour of "formats".
see [https://goreleaser.com/deprecations#archivesformat](https://goreleaser.com/deprecations#archivesformat)