### PR TITLE
Actions permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 name: Build
+permissions:
+  contents: read
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,10 +1,10 @@
 name: github pages
-
+permissions:
+  contents: write
 on:
   push:
     branches:
     - master
-
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -1,4 +1,6 @@
 name: goreleaser
+permissions:
+  contents: write
 on:
   push:
     tags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,8 @@ builds:
 archives:
   - id: bin
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}_{{ .Arch }}'
-    format: binary
+    formats:
+      - binary
 source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{.Version }}.src'


### PR DESCRIPTION
Setting an explicit permissions block for the principle of least privilege (CWE-275).
Also slipped in a tweak for deprecated outputs format in goreleaser.