### PR TITLE
Bump go.mod pins to latest point release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine3.21 AS build
+FROM golang:1.24.3-alpine3.21 AS build
 
 ARG consul_version=1.20.2
 ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-alpine3.21 AS build
+FROM golang:alpine AS build
 
 ARG consul_version=1.20.2
 ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip /usr/local/bin
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -trimpath -ldflags "-s -w" ./.
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w"
 RUN setcap cap_net_bind_service=+ep /src/fabio
 
-FROM alpine:3.21
+FROM alpine
 RUN apk update && apk add --no-cache ca-certificates
 COPY --from=build /src/fabio /usr/bin
 COPY --chown=nobody:nogroup fabio.properties /etc/fabio/fabio.properties

--- a/Dockerfile-goreleaser
+++ b/Dockerfile-goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine
 RUN apk update && apk add --no-cache ca-certificates
 COPY fabio /usr/bin
 ADD fabio.properties /etc/fabio/fabio.properties

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fabiolb/fabio
 
-go 1.24.0
+go 1.24.3
 
 require (
 	github.com/armon/go-proxyproto v0.0.0-20180202201750-5b7edb60ff5f


### PR DESCRIPTION
Because the setup go action pull the specific version in the go.mod files it won't pull-latest ref [actions/setup-go/issues/561](https://github.com/actions/setup-go/issues/561).