### PR TITLE
docs: Fixes bad example for creating multiple basic authorization schemes

### DIFF
--- a/docs/content/feature/authorization.md
+++ b/docs/content/feature/authorization.md
@@ -52,5 +52,5 @@ Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpas
     name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
 
     # basic auth with multiple schemes
-    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
+    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s,
                  name=myotherauth;type=basic;file=p/other-creds.htpasswd;realm=myrealm

--- a/docs/content/ref/proxy.auth.md
+++ b/docs/content/ref/proxy.auth.md
@@ -32,7 +32,7 @@ Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpas
     name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
 
     # basic auth with multiple schemes
-    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s
+    proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s,
                  name=myotherauth;type=basic;file=p/other-creds.htpasswd;realm=myrealm
 
 The default is


### PR DESCRIPTION
closes #929 

I traced the code path through parsing KV slices and the only way to create multiple maps is to separate with a comma. The examples in the docs will not work. This updates the docs.