### PR TITLE
feat: add armv7 support for docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -15,6 +15,8 @@ jobs:
           fetch-depth: 0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,12 +69,30 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
     extra_files:
       - fabio.properties
+  - dockerfile: Dockerfile-goreleaser
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - 'fabiolb/fabio:latest-armv7'
+      - 'fabiolb/fabio:{{ .Version }}-armv7'
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    extra_files:
+      - fabio.properties
 docker_manifests:
   - name_template: 'fabiolb/fabio:latest'
     image_templates:
       - 'fabiolb/fabio:latest-amd64'
       - 'fabiolb/fabio:latest-arm64v8'
+      - 'fabiolb/fabio:latest-armv7'
   - name_template: 'fabiolb/fabio:{{ .Version }}'
     image_templates:
       - 'fabiolb/fabio:{{ .Version }}-amd64'
       - 'fabiolb/fabio:{{ .Version }}-arm64v8'
+      - 'fabiolb/fabio:{{ .Version }}-armv7'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 FROM golang:alpine AS build
 
+ARG TARGETARCH
 ARG consul_version=1.21.4
-ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip /usr/local/bin
-RUN cd /usr/local/bin && unzip consul_${consul_version}_linux_amd64.zip consul
+ADD https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_${TARGETARCH}.zip /usr/local/bin
+RUN cd /usr/local/bin && unzip consul_${consul_version}_linux_${TARGETARCH}.zip consul
 
 ARG vault_version=1.20.3
-ADD https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_amd64.zip /usr/local/bin
-RUN cd /usr/local/bin && unzip vault_${vault_version}_linux_amd64.zip vault
+ADD https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_${TARGETARCH}.zip /usr/local/bin
+RUN cd /usr/local/bin && unzip vault_${vault_version}_linux_${TARGETARCH}.zip vault
 
 RUN apk update && apk add --no-cache git libcap
 WORKDIR /src
 COPY . .
 RUN go mod tidy
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -trimpath -ldflags "-s -w" ./...
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w"
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go test -trimpath -ldflags "-s -w" ./...
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -trimpath -ldflags "-s -w"
 RUN setcap cap_net_bind_service=+ep /src/fabio
 
 FROM alpine


### PR DESCRIPTION
# Add ARM32 (armv7) Multi-Architecture Docker Support

## Summary

This PR adds ARM32 (armv7) architecture support to Fabio's Docker images and makes the build process fully multi-architecture aware. Docker images will now be built for **three architectures**: `amd64`, `arm64`, and `armv7`.

## Changes Made

### 1. Updated Dockerfile
- Made consul/vault binary downloads architecture-aware using `${TARGETARCH}` variable
- Downloads correct binaries for each target platform (amd64, arm64, arm)
- Maintains original Dockerfile structure and test execution

### 2. Updated `.goreleaser.yml`
- Added ARM32 (armv7) Docker build configuration
- Creates multi-architecture manifests combining all three platforms:
  - `fabiolb/fabio:latest` → amd64, arm64v8, armv7
  - `fabiolb/fabio:{{ .Version }}` → amd64, arm64v8, armv7

### 3. Enhanced GitHub Actions Workflows
- Added Docker Buildx setup to build workflow
- Workflows now support building and pushing multi-arch images on release

## Why This Matters

### 1. **Broader Hardware Compatibility**
- Enables Fabio to run on ARM32 devices like Raspberry Pi 2/3/Zero 2
- Supports older ARM-based servers and embedded systems
- Expands deployment options for IoT and edge computing scenarios

### 2. **Cost-Effective Edge Deployments**
- ARM32 devices are significantly cheaper than ARM64 or x86_64 alternatives
- Perfect for home labs, small-scale deployments, and educational purposes
- Reduces hardware costs for development and testing environments

### 3. **Legacy Hardware Support**
- Extends the life of existing ARM32 infrastructure
- No need to upgrade hardware to run modern Fabio versions
- Supports organizations with investment in ARM32-based systems

### 4. **Seamless User Experience**
- Docker automatically pulls the correct architecture image
- No manual intervention required - just `docker pull fabiolb/fabio:latest`
- Single manifest works across all platforms

### 5. **Complete Platform Coverage**
- Covers the full spectrum of modern ARM devices (32-bit and 64-bit)
- Matches the breadth of platforms already supported in binary releases
- Ensures Docker deployment parity with standalone binary deployment options

## Testing

The Docker build process has been tested for all three architectures:
```bash
docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 \
  -t fabiolb/fabio:latest --push .
```

All architectures build successfully with full test execution.

## Breaking Changes

None. This is a purely additive change that expands platform support.
