### PR TITLE
fix: add TLS 1.3 to tlsver map and fix comment typo

### DIFF
--- a/proxy/http_headers.go
+++ b/proxy/http_headers.go
@@ -163,11 +163,12 @@ var tlsver = map[uint16]string{
 	tls.VersionTLS10: "tls10",
 	tls.VersionTLS11: "tls11",
 	tls.VersionTLS12: "tls12",
+	tls.VersionTLS13: "tls13",
 }
 
 var digit16 = []byte("0123456789abcdef")
 
-// uint16base64 is a faster version of fmt.Sprintf("0x%04x", n)
+// uint16base16 is a faster version of fmt.Sprintf("0x%04x", n)
 //
 // BenchmarkUint16Base16/fmt.Sprintf-8         	10000000	       154 ns/op	       8 B/op	       2 allocs/op
 // BenchmarkUint16Base16/uint16base16-8        	50000000	        35.0 ns/op	       8 B/op	       1 allocs/op

--- a/proxy/http_headers_test.go
+++ b/proxy/http_headers_test.go
@@ -152,6 +152,19 @@ func TestAddHeaders(t *testing.T) {
 			"",
 		},
 
+		{"set httpproto, tlsver and tlscipher on Forwarded for https and tls1.3",
+			&http.Request{RemoteAddr: "1.2.3.4:5555", Proto: "HTTP/2.0", TLS: &tls.ConnectionState{Version: tls.VersionTLS13, CipherSuite: tls.TLS_CHACHA20_POLY1305_SHA256}},
+			config.Proxy{},
+			"",
+			http.Header{
+				"Forwarded":         []string{"for=1.2.3.4; proto=https; httpproto=http/2.0; tlsver=tls13; tlscipher=0x1303"},
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Port":  []string{"443"},
+				"X-Real-Ip":         []string{"1.2.3.4"},
+			},
+			"",
+		},
+
 		{"set httpproto on Forwarded",
 			&http.Request{RemoteAddr: "1.2.3.4:5555", Proto: "HTTP/1.1"},
 			config.Proxy{},


### PR DESCRIPTION
Closes #1029

## Problem

The `tlsver` map in `proxy/http_headers.go` was missing an entry for TLS 1.3 (`tls.VersionTLS13`). 

When a TLS 1.3 connection is made, `tlsver[r.TLS.Version]` returns an empty string, causing the fallback `uint16base16(r.TLS.Version)` to produce the raw hex value `0x0304` in the `Forwarded` header instead of the human-readable string `tls13`.

**Before (TLS 1.3 connection):**
```
Forwarded: for=1.2.3.4; proto=https; httpproto=http/1.1; tlsver=0x0304; tlscipher=...
```

**After (TLS 1.3 connection):**
```
Forwarded: for=1.2.3.4; proto=https; httpproto=http/1.1; tlsver=tls13; tlscipher=...
```

TLS 1.3 is the current recommended TLS version, so this bug affects most modern clients that use the `Forwarded` header's `tlsver` attribute.

Additionally, the comment above `uint16base16` contained a typo — it incorrectly said `uint16base64`.

## Fix

1. Added `tls.VersionTLS13: "tls13"` to the `tlsver` map.
2. Fixed comment typo: `uint16base64` → `uint16base16`.