### PR TITLE
Adds service tag to requests and http.status metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -349,10 +349,10 @@ func startServers(cfg *config.Config, stats metrics.Provider) {
 
 	httpCounters := func() {
 		httpStatsHandler = &proxy.HttpStatsHandler{
-			Requests:        stats.NewHistogram("requests"),
+			Requests:        stats.NewHistogram("requests", "service"),
 			Noroute:         notFound,
 			WSConn:          stats.NewGauge("ws.conn"),
-			StatusTimer:     stats.NewHistogram("http.status", "code"),
+			StatusTimer:     stats.NewHistogram("http.status", "code", "service"),
 			RedirectCounter: stats.NewCounter("http.redirect.count", "code"),
 		}
 	}

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -228,7 +228,7 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	dur := end.Sub(start)
 
 	if p.Stats.Requests != nil {
-		p.Stats.Requests.Observe(dur.Seconds())
+		p.Stats.Requests.With("service", t.Service).Observe(dur.Seconds())
 	}
 	if t.Timer != nil {
 		t.Timer.Observe(dur.Seconds())
@@ -238,7 +238,7 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if p.Stats.StatusTimer != nil {
-		p.Stats.StatusTimer.With("code", strconv.Itoa(rw.code)).Observe(dur.Seconds())
+		p.Stats.StatusTimer.With("code", strconv.Itoa(rw.code), "service", t.Service).Observe(dur.Seconds())
 	}
 
 	// write access log


### PR DESCRIPTION
❯ go run ./demo/server/server.go -prefix /foo
❯ curl http://localhost:9999/foo/bar

Before:
```
prefix1_fabiows.conn:0.000000|g
prefix1_fabiorequests:4.510044|h
prefix1_fabioroute:0.004510|h|#fabio-service:server,fabio-host:,path:/foo,target:http://127.0.0.1:5000/
prefix1_fabiohttp.status:0.004510|h|#code:404
```

After:
```
prefix1_fabiows.conn:0.000000|g
prefix1_fabiorequests:0.000543|h|#fabio-service:server
prefix1_fabioroute:0.000543|h|#fabio-service:server,fabio-host:,path:/foo,target:http://127.0.0.1:5000/
prefix1_fabiohttp.status:0.000543|h|#code:404,fabio-service:server
```