### PR TITLE
Fix delta log route format to be line aware

### DIFF
--- a/main.go
+++ b/main.go
@@ -677,7 +677,11 @@ func logRoutes(t route.Table, last, next, format string) {
 		log.Printf("[INFO] Updated config to\n%s", t.Dump())
 
 	case "delta":
-		if delta := fmtDiff(dmp.New().DiffMain(last, next, true)); delta != "" {
+		dmp := dmp.New()
+		chars1, chars2, lineArray := dmp.DiffLinesToChars(last, next)
+		diffs := dmp.DiffMain(chars1, chars2, false)
+		diffs = dmp.DiffCharsToLines(diffs, lineArray)
+		if delta := fmtDiff(diffs); delta != "" {
 			log.Printf("[INFO] Config updates\n%s", delta)
 		}
 


### PR DESCRIPTION
The existing delta is not sensitive to end of lines and tries to make a diff across new lines.
This change relies on routes being on different lines to make a better delta log.

❯ consul agent -dev
❯ ./fabio 
❯ go run ./demo/server/server.go -addr 127.0.0.1:5000 -name foo-service -prefix /foo    -proto http
❯ go run ./demo/server/server.go -addr 127.0.0.1:5002 -name foo-service -prefix /foo    -proto http
❯ go run ./demo/server/server.go -addr 127.0.0.1:5001 -name foo-service -prefix /foo    -proto http

logs before:
```
2026/07/14 16:13:58 [INFO] Config updates
+ route add foo-service /foo http://127.0.0.1:5001/
2026/07/14 16:14:18 [INFO] Config updates
+ route add foo-service /foo http://127.0.0.1:5002/
2026/07/14 16:14:32 [INFO] Config updates
- 1/
- route add foo-service /foo http://127.0.0.1:500
```

logs after:
```
2026/07/14 16:48:16 [INFO] Config updates
+ route add foo-service /foo http://127.0.0.1:5000/
2026/07/14 16:48:21 [INFO] Config updates
+ route add foo-service /foo http://127.0.0.1:5002/
2026/07/14 16:48:29 [INFO] Config updates
+ route add foo-service /foo http://127.0.0.1:5001/
```