### PR TITLE
Fix excessive "[WARN] No route for" logs for tcp-dynamic

### DIFF
--- a/main.go
+++ b/main.go
@@ -249,6 +249,21 @@ func newHTTPProxy(cfg *config.Config, statsHandler *proxy.HttpStatsHandler) *pro
 	}
 }
 
+func lookupDynamicTcpHostFn(cfg *config.Config, notFound gkm.Counter) func([]string) *route.Target {
+	pick := route.Picker[cfg.Proxy.Strategy]
+	return func(hosts []string) *route.Target {
+		for _, host := range hosts {
+			t := route.GetTable().LookupHost(host, pick)
+			if t != nil {
+				return t
+			}
+		}
+		notFound.Add(1)
+		log.Print("[WARN] No route for any hosts: ", hosts)
+		return nil
+	}
+}
+
 func lookupHostFn(cfg *config.Config, notFound gkm.Counter) func(string) *route.Target {
 	pick := route.Picker[cfg.Proxy.Strategy]
 	return func(host string) *route.Target {
@@ -470,7 +485,7 @@ func startServers(cfg *config.Config, stats metrics.Provider) {
 						go func() {
 							h := &tcp.DynamicProxy{
 								DialTimeout: cfg.Proxy.DialTimeout,
-								Lookup:      lookupHostFn(cfg, notFound),
+								Lookup:      lookupDynamicTcpHostFn(cfg, notFound),
 								Conn:        tcpConn,
 								ConnFail:    tcpConnFail,
 								Noroute:     tcpNoRoute,

--- a/proxy/tcp/tcp_dynamic_proxy.go
+++ b/proxy/tcp/tcp_dynamic_proxy.go
@@ -24,7 +24,7 @@ type DynamicProxy struct {
 
 	// Lookup returns a target host for the given request.
 	// The proxy will panic if this value is nil.
-	Lookup func(host string) *route.Target
+	Lookup func(hosts []string) *route.Target
 
 	// DialTimeout sets the timeout for establishing the outbound
 	// connection.
@@ -39,11 +39,8 @@ func (p *DynamicProxy) ServeTCP(in net.Conn) error {
 	}
 
 	target := in.LocalAddr().String()
-	t := p.Lookup(target)
-	if t == nil {
-		_, port, _ := net.SplitHostPort(target)
-		t = p.Lookup(":" + port)
-	}
+	_, port, _ := net.SplitHostPort(target)
+	t := p.Lookup([]string{target, ":" + port})
 	if t == nil {
 		if p.Noroute != nil {
 			p.Noroute.Add(1)

--- a/proxy/tcp_integration_test.go
+++ b/proxy/tcp_integration_test.go
@@ -41,9 +41,12 @@ func TestTCPDyanmicProxy(t *testing.T) {
 	proxyAddr := "127.0.0.1:57778"
 	go func() {
 		h := &tcp.DynamicProxy{
-			Lookup: func(h string) *route.Target {
+			Lookup: func(hosts []string) *route.Target {
 				tbl, _ := route.NewTable(bytes.NewBufferString("route add srv 127.0.0.1:57778 tcp://" + srv.Addr))
-				return tbl.LookupHost(h, route.Picker["rr"])
+				for _, h := range hosts {
+					return tbl.LookupHost(h, route.Picker["rr"])
+				}
+				return nil
 			},
 		}
 		l := config.Listen{Addr: proxyAddr}


### PR DESCRIPTION
Refactors lookup function to accept an array of hosts to lookup.

Fixes #1060 