### PR TITLE
docs/features: add missing "authorization" feature to the index

### DIFF
--- a/docs/content/feature/_index.md
+++ b/docs/content/feature/_index.md
@@ -5,24 +5,24 @@ weight: 200
 
 The following list provides a list of features supported by fabio. 
 
- * [Access Logging](/feature/access-logging/) - customizable access logs
  * [Access Control](/feature/access-control/) - route specific access control
+ * [Access Logging](/feature/access-logging/) - customizable access logs
+ * [BGP Support](/feature/bgp) - bgp support
  * [Certificate Stores](/feature/certificate-stores/) - dynamic certificate stores like file system, HTTP server, [Consul](https://consul.io/) and [Vault](https://vaultproject.io/)
  * [Compression](/feature/http-compression/) - GZIP compression for HTTP responses
  * [Docker Support](/feature/docker/) - Official Docker image, Registrator and Docker Compose example
  * [Dynamic Reloading](/feature/dynamic-reloading/) - hot reloading of the routing table without downtime
  * [Graceful Shutdown](/feature/graceful-shutdown/) - wait until requests have completed before shutting down
  * [HTTP Header Support](/feature/http-headers/) - inject some HTTP headers into upstream requests
+ * [HTTPS TCP-SNI Proxy Support](/feature/https-tcp-sni-proxy/) - forward TLS connections based on hostname without re-encryption, or fallback to fabio terminating TLS and path routing as a fallback
  * [HTTPS Upstreams](/feature/https-upstream/) - forward requests to HTTPS upstream servers
  * [Metrics Support](/feature/metrics/) - support for Graphite, StatsD/DataDog and Circonus
- * [PROXY Protocol Support](/feature/proxy-protocol/) - support for HA Proxy PROXY protocol for inbound requests (use for Amazon ELB)
- * [Path Stripping](/feature/http-path-stripping/) - strip prefix paths from incoming requests
  * [Path Prepending](/feature/http-path-prepending/) - prepend a prefix path on to incoming requests
+ * [Path Stripping](/feature/http-path-stripping/) - strip prefix paths from incoming requests
+ * [PROXY Protocol Support](/feature/proxy-protocol/) - support for HA Proxy PROXY protocol for inbound requests (use for Amazon ELB)
  * [Server-Sent Events/SSE](/feature/sse/) - support for Server-Sent Events/SSE
  * [TCP Proxy Support](/feature/tcp-proxy/) - raw TCP proxy support
  * [TCP-SNI Proxy Support](/feature/tcp-sni-proxy/) - forward TLS connections based on hostname without re-encryption
- * [HTTPS TCP-SNI Proxy Support](/feature/https-tcp-sni-proxy/) - forward TLS connections based on hostname without re-encryption, or fallback to fabio terminating TLS and path routing as a fallback
  * [Traffic Shaping](/feature/traffic-shaping/) - forward N% of traffic upstream without knowing the number of instances
  * [Web UI](/feature/web-ui/) - web ui to examine the current routing table
  * [Websocket Support](/feature/websockets/) - websocket support
- * [BGP Support](/feature/bgp) - bgp support

--- a/docs/content/feature/_index.md
+++ b/docs/content/feature/_index.md
@@ -3,26 +3,31 @@ title: "Features"
 weight: 200
 ---
 
-The following list provides a list of features supported by fabio. 
+Fabio supports the following:
 
  * [Access Control](/feature/access-control/) - route specific access control
  * [Access Logging](/feature/access-logging/) - customizable access logs
+ * [Authorization](/feature/authorization/) - authorization mechanisms
  * [BGP Support](/feature/bgp) - bgp support
  * [Certificate Stores](/feature/certificate-stores/) - dynamic certificate stores like file system, HTTP server, [Consul](https://consul.io/) and [Vault](https://vaultproject.io/)
- * [Compression](/feature/http-compression/) - GZIP compression for HTTP responses
  * [Docker Support](/feature/docker/) - Official Docker image, Registrator and Docker Compose example
  * [Dynamic Reloading](/feature/dynamic-reloading/) - hot reloading of the routing table without downtime
  * [Graceful Shutdown](/feature/graceful-shutdown/) - wait until requests have completed before shutting down
+ * [GRPC Proxy](/feature/grpc-proxy/) - Transparent GRPC proxy
+ * [HTTP Compression](/feature/http-compression/) - GZIP compression for HTTP responses
  * [HTTP Header Support](/feature/http-headers/) - inject some HTTP headers into upstream requests
+ * [HTTP Path Prepending](/feature/http-path-prepending/) - prepend a prefix path on to incoming requests
+ * [HTTP Path Stripping](/feature/http-path-stripping/) - strip prefix paths from incoming requests
+ * [HTTP redirects](/feature/http-redirects/) - redirect HTTP requests
  * [HTTPS TCP-SNI Proxy Support](/feature/https-tcp-sni-proxy/) - forward TLS connections based on hostname without re-encryption, or fallback to fabio terminating TLS and path routing as a fallback
  * [HTTPS Upstreams](/feature/https-upstream/) - forward requests to HTTPS upstream servers
  * [Metrics Support](/feature/metrics/) - support for Graphite, StatsD/DataDog and Circonus
- * [Path Prepending](/feature/http-path-prepending/) - prepend a prefix path on to incoming requests
- * [Path Stripping](/feature/http-path-stripping/) - strip prefix paths from incoming requests
  * [PROXY Protocol Support](/feature/proxy-protocol/) - support for HA Proxy PROXY protocol for inbound requests (use for Amazon ELB)
  * [Server-Sent Events/SSE](/feature/sse/) - support for Server-Sent Events/SSE
+ * [TCP dynamic proxy](/feature/tcp-dynamic-proxy/) - TCP proxy based on urlprefix tag
  * [TCP Proxy Support](/feature/tcp-proxy/) - raw TCP proxy support
  * [TCP-SNI Proxy Support](/feature/tcp-sni-proxy/) - forward TLS connections based on hostname without re-encryption
  * [Traffic Shaping](/feature/traffic-shaping/) - forward N% of traffic upstream without knowing the number of instances
+ * [Vault](/feature/vault/) - Store or generate certificates with HashiCorp Vault
  * [Web UI](/feature/web-ui/) - web ui to examine the current routing table
  * [Websocket Support](/feature/websockets/) - websocket support


### PR DESCRIPTION
Note: many more features are not listed in the manual index, although they are automatically listed in the left column

<img width="1946" height="924" alt="fabio" src="https://github.com/user-attachments/assets/24c35fd1-4f03-4e73-a7e9-0975d94456bf" />

**EDIT**

An alternative is to delete everything in this index page and only write something like:

> All the features provided by fabio are listed by the column on the left, have a look!

What do you think ?