### PR TITLE
Adjust for Go 1.27 changes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9.0
+          version: v2.13.1
   build:
     runs-on: ubuntu-latest
     needs: ["golangci"]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,7 @@ linters:
     - errorlint
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5
     - forbidigo
     - forcetypeassert
     - funcorder
@@ -50,6 +51,7 @@ linters:
     - godoclint
     - godot
     - godox
+    - gomodguard
     - gosec
     - govet
     - ireturn

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fabiolb/fabio
 
-go 1.26.5
+go 1.27.0
 
 require (
 	github.com/circonus-labs/circonus-gometrics/v3 v3.4.7

--- a/metrics/provider_flat.go
+++ b/metrics/provider_flat.go
@@ -27,7 +27,7 @@ func (p *flatProvider) NewHistogram(name string, labels ...string) gkm.Histogram
 
 type flatCounter struct {
 	Name string
-	v    uint64
+	v    atomic.Uint64
 }
 
 func (c *flatCounter) With(labelValues ...string) gkm.Counter {
@@ -35,18 +35,18 @@ func (c *flatCounter) With(labelValues ...string) gkm.Counter {
 }
 
 func (c *flatCounter) Add(v float64) {
-	uv := atomic.AddUint64(&c.v, uint64(v))
+	uv := c.v.Add(uint64(v))
 	fmt.Printf("%s:%d|c\n", c.Name, uv)
 }
 
 type flatGauge struct {
 	Name string
 	// Stolen from prometheus client gauge
-	valBits uint64
+	valBits atomic.Uint64
 }
 
 func (g *flatGauge) Set(n float64) {
-	atomic.StoreUint64(&g.valBits, math.Float64bits(n))
+	g.valBits.Store(math.Float64bits(n))
 	fmt.Printf("%s:%d|g\n", g.Name, int(n))
 }
 
@@ -54,9 +54,9 @@ func (g *flatGauge) Add(delta float64) {
 	var oldBits uint64
 	var newBits uint64
 	for {
-		oldBits = atomic.LoadUint64(&g.valBits)
+		oldBits = g.valBits.Load()
 		newBits = math.Float64bits(math.Float64frombits(oldBits) + delta)
-		if atomic.CompareAndSwapUint64(&g.valBits, oldBits, newBits) {
+		if g.valBits.CompareAndSwap(oldBits, newBits) {
 			break
 		}
 	}

--- a/metrics/provider_label.go
+++ b/metrics/provider_label.go
@@ -56,7 +56,7 @@ type labelGauge struct {
 	Name    string
 	Labels  []string
 	Values  []string
-	valBits uint64
+	valBits atomic.Uint64
 }
 
 func (g *labelGauge) With(labelValues ...string) gkm.Gauge {
@@ -70,7 +70,7 @@ func (g *labelGauge) With(labelValues ...string) gkm.Gauge {
 }
 
 func (g *labelGauge) Set(n float64) {
-	atomic.StoreUint64(&g.valBits, math.Float64bits(n))
+	g.valBits.Store(math.Float64bits(n))
 	fmt.Printf("%s:%d|g%s\n", g.Name, int(n), Labels(g.Labels, g.Values, "|#", ":", ","))
 }
 
@@ -78,9 +78,9 @@ func (g *labelGauge) Add(delta float64) {
 	var oldBits uint64
 	var newBits uint64
 	for {
-		oldBits = atomic.LoadUint64(&g.valBits)
+		oldBits = g.valBits.Load()
 		newBits = math.Float64bits(math.Float64frombits(oldBits) + delta)
-		if atomic.CompareAndSwapUint64(&g.valBits, oldBits, newBits) {
+		if g.valBits.CompareAndSwap(oldBits, newBits) {
 			break
 		}
 	}

--- a/proxy/http_handler.go
+++ b/proxy/http_handler.go
@@ -16,19 +16,25 @@ const StatusClientClosedRequest = 499
 
 func newHTTPProxy(target *url.URL, tr http.RoundTripper, flush time.Duration) http.Handler {
 	return &httputil.ReverseProxy{
-		// this is a simplified director function based on the
-		// httputil.NewSingleHostReverseProxy() which does not
-		// mangle the request and target URL since the target
-		// URL is already in the correct format.
-		Director: func(req *http.Request) {
-			req.URL.Scheme = target.Scheme
-			req.URL.Host = target.Host
-			req.URL.Path = target.Path
-			req.URL.RawQuery = target.RawQuery
-			if _, ok := req.Header["User-Agent"]; !ok {
+		Rewrite: func(req *httputil.ProxyRequest) {
+			req.Out.URL.Scheme = target.Scheme
+			req.Out.URL.Host = target.Host
+			req.Out.URL.Path = target.Path
+			req.Out.URL.RawQuery = target.RawQuery
+			if _, ok := req.Out.Header["User-Agent"]; !ok {
 				// explicitly disable User-Agent so it's not set to default value
-				req.Header.Set("User-Agent", "")
+				req.Out.Header.Set("User-Agent", "")
 			}
+
+			// Preserve X-Forwarded-For from inbound request before calling SetXForwarded
+			// SetXForwarded will append the client IP to it
+			if xff := req.In.Header.Get("X-Forwarded-For"); xff != "" {
+				req.Out.Header.Set("X-Forwarded-For", xff)
+			}
+
+			// SetXForwarded will handle X-Forwarded-For (append), X-Forwarded-Host, and X-Forwarded-Proto
+			// Other headers (X-Forwarded-Port, X-Forwarded-Prefix, Forwarded) are already set by addHeaders()
+			req.SetXForwarded()
 		},
 		FlushInterval: flush,
 		Transport:     tr,

--- a/proxy/http_handler_test.go
+++ b/proxy/http_handler_test.go
@@ -1,0 +1,150 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// BenchmarkNewHTTPProxy benchmarks the httputil.ReverseProxy created by newHTTPProxy
+// with focus on the Rewrite function and header manipulation including SetXForwarded
+func BenchmarkNewHTTPProxy(b *testing.B) {
+	// Create a simple backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	tests := []struct {
+		name          string
+		flushInterval time.Duration
+		headers       map[string]string
+	}{
+		{
+			name:          "no flush with basic headers",
+			flushInterval: 0,
+			headers: map[string]string{
+				"User-Agent": "test-agent",
+			},
+		},
+		{
+			name:          "no flush with forwarded headers",
+			flushInterval: 0,
+			headers: map[string]string{
+				"X-Forwarded-For":    "1.2.3.4",
+				"X-Forwarded-Port":   "8080",
+				"X-Forwarded-Prefix": "/api",
+				"Forwarded":          "for=1.2.3.4",
+			},
+		},
+		{
+			name:          "with flush interval",
+			flushInterval: 10 * time.Millisecond,
+			headers: map[string]string{
+				"X-Forwarded-For": "1.2.3.4",
+			},
+		},
+		{
+			name:          "no user agent header",
+			flushInterval: 0,
+			headers:       map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			// Create the proxy handler using newHTTPProxy
+			proxy := newHTTPProxy(backendURL, http.DefaultTransport, tt.flushInterval)
+
+			// Create a test request
+			req := httptest.NewRequest("GET", "http://example.com/test?foo=bar", nil)
+			req.RemoteAddr = "127.0.0.1:12345"
+
+			// Add headers
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for range b.N {
+				w := httptest.NewRecorder()
+				proxy.ServeHTTP(w, req)
+			}
+		})
+	}
+}
+
+// BenchmarkNewHTTPProxyRewrite specifically benchmarks the Rewrite function overhead
+func BenchmarkNewHTTPProxyRewrite(b *testing.B) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Minimal backend to isolate proxy overhead
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	proxy := newHTTPProxy(backendURL, http.DefaultTransport, 0)
+
+	b.Run("with SetXForwarded", func(b *testing.B) {
+		req := httptest.NewRequest("GET", "http://example.com/api/v1/users", nil)
+		req.RemoteAddr = "192.168.1.100:54321"
+		req.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
+		req.Header.Set("X-Forwarded-Port", "443")
+		req.Header.Set("X-Forwarded-Prefix", "/api")
+		req.Header.Set("Forwarded", "for=10.0.0.1;proto=https")
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for range b.N {
+			w := httptest.NewRecorder()
+			proxy.ServeHTTP(w, req)
+		}
+	})
+
+	b.Run("without existing forwarded headers", func(b *testing.B) {
+		req := httptest.NewRequest("GET", "http://example.com/api/v1/users", nil)
+		req.RemoteAddr = "192.168.1.100:54321"
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for range b.N {
+			w := httptest.NewRecorder()
+			proxy.ServeHTTP(w, req)
+		}
+	})
+}
+
+// BenchmarkNewHTTPProxyParallel benchmarks concurrent requests through the proxy
+func BenchmarkNewHTTPProxyParallel(b *testing.B) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+	proxy := newHTTPProxy(backendURL, http.DefaultTransport, 0)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	b.RunParallel(func(pb *testing.PB) {
+		req := httptest.NewRequest("GET", "http://example.com/test", nil)
+		req.RemoteAddr = "127.0.0.1:12345"
+		req.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+		for pb.Next() {
+			w := httptest.NewRecorder()
+			proxy.ServeHTTP(w, req)
+		}
+	})
+}

--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -298,9 +299,9 @@ func TestProxyHost(t *testing.T) {
 	proxy := httptest.NewServer(&HTTPProxy{
 		ProtectHeaders: testProtectHeaders,
 		Transport: &http.Transport{
-			Dial: func(network, _ string) (net.Conn, error) {
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
 				addr := server.URL[len("http://"):]
-				return net.Dial(network, addr)
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
 			},
 		},
 		Lookup: func(r *http.Request) *route.Target {

--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -427,22 +427,25 @@ func TestPathRedirect(t *testing.T) {
 }
 
 func TestProxyLogOutput(t *testing.T) {
+	const responseBody = "foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+	compressedSize := len(compress([]byte(responseBody)))
+
 	t.Run("uncompressed response", func(t *testing.T) {
-		testProxyLogOutput(t, 73, config.Proxy{})
+		testProxyLogOutput(t, responseBody, len(responseBody), config.Proxy{})
 	})
 	t.Run("compression enabled but no match", func(t *testing.T) {
-		testProxyLogOutput(t, 73, config.Proxy{
+		testProxyLogOutput(t, responseBody, len(responseBody), config.Proxy{
 			GZIPContentTypes: regexp.MustCompile(`^$`),
 		})
 	})
 	t.Run("compression enabled and active", func(t *testing.T) {
-		testProxyLogOutput(t, 28, config.Proxy{
+		testProxyLogOutput(t, responseBody, compressedSize, config.Proxy{
 			GZIPContentTypes: regexp.MustCompile(`.*`),
 		})
 	})
 }
 
-func testProxyLogOutput(t *testing.T, bodySize int, cfg config.Proxy) {
+func testProxyLogOutput(t *testing.T, responseBody string, bodySize int, cfg config.Proxy) {
 	t.Helper()
 
 	// build a format string from all log fields and one header field
@@ -461,7 +464,7 @@ func testProxyLogOutput(t *testing.T, bodySize int, cfg config.Proxy) {
 
 	// create an upstream server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo")
+		fmt.Fprint(w, responseBody)
 	}))
 	defer server.Close()
 

--- a/proxy/serve.go
+++ b/proxy/serve.go
@@ -217,10 +217,9 @@ func serve(ln net.Listener, srv Server) error {
 	mu.Unlock()
 	err := srv.Serve(ln)
 	if err != nil {
-		var opErr *net.OpError
 		if errors.Is(err, http.ErrServerClosed) {
 			err = nil
-		} else if errors.As(err, &opErr) {
+		} else if opErr, ok := errors.AsType[*net.OpError](err); ok {
 			if opErr.Err != nil && opErr.Err.Error() == "use of closed network connection" {
 				err = nil
 			}

--- a/proxy/ws_handler.go
+++ b/proxy/ws_handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 // conns keeps track of the number of open ws connections
-var conns int64
+var conns atomic.Int64
 
 type dialFunc func(network, address string) (net.Conn, error)
 
@@ -24,9 +24,9 @@ type dialFunc func(network, address string) (net.Conn, error)
 func newWSHandler(host string, dial dialFunc, conn gkm.Gauge) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if conn != nil {
-			conn.Set(float64(atomic.AddInt64(&conns, 1)))
+			conn.Set(float64(conns.Add(1)))
 			defer func() {
-				conn.Set(float64(atomic.AddInt64(&conns, -1)))
+				conn.Set(float64(conns.Add(-1)))
 			}()
 		}
 

--- a/route/route_bench_test.go
+++ b/route/route_bench_test.go
@@ -118,7 +118,7 @@ func makeRoutes(domains, paths, depth, urls int) Table {
 			for k := range depth {
 				prefix := fmt.Sprintf("www.host-%d.com/path-%d/", i, k)
 				for range urls {
-					s.WriteString(fmt.Sprintf("route add svc %s http://host:12345/\n", prefix))
+					fmt.Fprintf(&s, "route add svc %s http://host:12345/\n", prefix)
 				}
 			}
 		}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -16,10 +16,10 @@ func NewTransport(tlscfg *tls.Config) *http.Transport {
 		ResponseHeaderTimeout: cfg.Proxy.ResponseHeaderTimeout,
 		IdleConnTimeout:       cfg.Proxy.IdleConnTimeout,
 		MaxIdleConnsPerHost:   cfg.Proxy.MaxConn,
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   cfg.Proxy.DialTimeout,
 			KeepAlive: cfg.Proxy.KeepAliveTimeout,
-		}).Dial,
+		}).DialContext,
 		TLSClientConfig: tlscfg,
 	}
 }


### PR DESCRIPTION
Updates to Go 1.27 and associated fixes to accommodate deprecations.

Some magic numbers needed adjusting due to changes in how Go 1.27 compresses strings, by replacing them with a calculated value.

One of the larger changes is the deprecation of the Director used in httputil.ReverseProxy.

finally Golangci-lint needed updating and some tweaks to make the code pass newer stricter linting checks.