### PR TITLE
tidy up and increase test coverage for basic auth

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -42,15 +42,8 @@ func TestLoadAuthSchemes(t *testing.T) {
 	})
 
 	t.Run("should load multiple auth schemes", func(t *testing.T) {
-		myauth, err := createBasicAuthFile("foo:bar", t)
-		if err != nil {
-			t.Fatalf("could not create file on disk %s", err)
-		}
-
-		myotherauth, err := createBasicAuthFile("bar:foo", t)
-		if err != nil {
-			t.Fatalf("could not create file on disk %s", err)
-		}
+		myauth := createBasicAuthFile(t, "foo:bar")
+		myotherauth := createBasicAuthFile(t, "bar:foo")
 
 		result, _ := LoadAuthSchemes(map[string]config.AuthScheme{
 			"myauth": {

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -19,7 +19,7 @@ type basic struct {
 
 func newBasicAuth(cfg config.BasicAuth) (AuthScheme, error) {
 	bad := func(err error) {
-		log.Println("[WARN] Error processing a line in an htpasswd file:", err)
+		log.Println("[WARN] Error processing htpasswd file:", err)
 	}
 
 	secrets, err := htpasswd.New(cfg.File, htpasswd.DefaultSystems, bad)

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -161,7 +160,7 @@ func TestBasic_Authorised(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, want := basicAuth.Authorized(tt.req, tt.res), tt.out; !reflect.DeepEqual(got, want) {
+			if got, want := basicAuth.Authorized(tt.req, tt.res), tt.out; got != want {
 				t.Errorf("got %v want %v", got, want)
 			}
 		})
@@ -192,7 +191,7 @@ func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
 	w := &responseWriter{}
 
 	t.Run("should authorize against supplied htpasswd file", func(t *testing.T) {
-		if got, want := a.Authorized(r, w), true; !reflect.DeepEqual(got, want) {
+		if got, want := a.Authorized(r, w), true; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}
 	})
@@ -204,7 +203,7 @@ func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
 	time.Sleep(2 * time.Second) // ensure htpasswd file refresh happened
 
 	t.Run("should not authorize after removing htpasswd file", func(t *testing.T) {
-		if got, want := a.Authorized(r, w), false; !reflect.DeepEqual(got, want) {
+		if got, want := a.Authorized(r, w), false; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}
 	})

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -34,69 +34,56 @@ func (rw *responseWriter) WriteHeader(statusCode int) {
 	rw.code = statusCode
 }
 
-func createBasicAuthFile(contents string, t *testing.T) (string, error) {
+func createBasicAuthFile(t *testing.T, contents string) string {
+	t.Helper()
 	dir := t.TempDir()
 
 	filename := fmt.Sprintf("%s/%s", dir, uuid.NewUUID())
 
 	err := os.WriteFile(filename, []byte(contents), 0666)
-
 	if err != nil {
-		return "", fmt.Errorf("could not write password file: %s", err)
+		t.Fatalf("could not write basic auth password file: %s", err)
 	}
 
-	return filename, nil
+	return filename
 }
 
-func createBasicAuth(user string, password string, t *testing.T) (AuthScheme, error) {
+func createBasicAuth(t *testing.T, user string, password string) AuthScheme {
+	t.Helper()
 	contents := fmt.Sprintf("%s:%s", user, password)
 
-	filename, err := createBasicAuthFile(contents, t)
-	if err != nil {
-		return nil, fmt.Errorf("could not create basic auth: %s", err)
-	}
+	filename := createBasicAuthFile(t, contents)
 
-	a, err := newBasicAuth(config.BasicAuth{
+	basicAuth, err := newBasicAuth(config.BasicAuth{
 		File:  filename,
 		Realm: "testrealm",
 	})
-
 	if err != nil {
-		return nil, fmt.Errorf("could not create basic auth: %s", err)
+		t.Fatalf("could not create basic auth: %s", err)
 	}
 
-	return a, nil
+	return basicAuth
 }
 
 func TestNewBasicAuth(t *testing.T) {
 
 	t.Run("should create a basic auth scheme from the supplied config", func(t *testing.T) {
-		filename, err := createBasicAuthFile("foo:bar", t)
+		filename := createBasicAuthFile(t, "foo:bar")
 
-		if err != nil {
-			t.Error(err)
-		}
-
-		_, err = newBasicAuth(config.BasicAuth{
+		_, err := newBasicAuth(config.BasicAuth{
 			File: filename,
 		})
-
 		if err != nil {
 			t.Error(err)
 		}
 	})
 
 	t.Run("should log a warning when credentials are malformed", func(t *testing.T) {
-		filename, err := createBasicAuthFile("foosdlijdgohdgdbar", t)
+		filename := createBasicAuthFile(t, "foosdlijdgohdgdbar")
 
-		if err != nil {
-			t.Error(err)
-		}
-
-		_, err = newBasicAuth(config.BasicAuth{
+		_, err := newBasicAuth(config.BasicAuth{
 			File: filename,
 		})
-
 		if err != nil {
 			t.Error(err)
 		}
@@ -104,12 +91,8 @@ func TestNewBasicAuth(t *testing.T) {
 }
 
 func TestBasic_Authorised(t *testing.T) {
-	basicAuth, err := createBasicAuth("foo", "bar", t)
+	basicAuth := createBasicAuth(t, "foo", "bar")
 	creds := []byte("foo:bar")
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	tests := []struct {
 		name string
@@ -167,12 +150,9 @@ func TestBasic_Authorised(t *testing.T) {
 }
 
 func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
-	filename, err := createBasicAuthFile("foo:bar", t)
-	if err != nil {
-		t.Error(err)
-	}
+	filename := createBasicAuthFile(t, "foo:bar")
 
-	a, err := newBasicAuth(config.BasicAuth{
+	basicAuth, err := newBasicAuth(config.BasicAuth{
 		File:    filename,
 		Refresh: time.Second,
 	})
@@ -190,7 +170,7 @@ func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
 	w := &responseWriter{}
 
 	t.Run("should authorize against supplied htpasswd file", func(t *testing.T) {
-		if got, want := a.Authorized(r, w), true; got != want {
+		if got, want := basicAuth.Authorized(r, w), true; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}
 	})
@@ -202,18 +182,14 @@ func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
 	time.Sleep(2 * time.Second) // ensure htpasswd file refresh happened
 
 	t.Run("should not authorize after removing htpasswd file", func(t *testing.T) {
-		if got, want := a.Authorized(r, w), false; got != want {
+		if got, want := basicAuth.Authorized(r, w), false; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}
 	})
 }
 
 func TestBasic_Authorized_should_set_www_realm_header(t *testing.T) {
-	basicAuth, err := createBasicAuth("foo", "bar", t)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	basicAuth := createBasicAuth(t, "foo", "bar")
 
 	rw := &responseWriter{}
 

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -115,7 +115,7 @@ func TestBasic_Authorised(t *testing.T) {
 		name string
 		req  *http.Request
 		res  http.ResponseWriter
-		out  bool
+		want bool
 	}{
 		{
 			"correct credentials should be authorized",
@@ -159,8 +159,8 @@ func TestBasic_Authorised(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, want := basicAuth.Authorized(tt.req, tt.res), tt.out; got != want {
-				t.Errorf("got %v want %v", got, want)
+			if got := basicAuth.Authorized(tt.req, tt.res); got != tt.want {
+				t.Errorf("got %v want %v", got, tt.want)
 			}
 		})
 	}

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -223,7 +222,7 @@ func TestBasic_Authorized_should_set_www_realm_header(t *testing.T) {
 	got := rw.Header().Get("WWW-Authenticate")
 	want := `Basic realm="testrealm"`
 
-	if strings.Compare(got, want) != 0 {
+	if got != want {
 		t.Errorf("got '%s', want '%s'", got, want)
 	}
 }

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -1,10 +1,13 @@
 package auth
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,13 +87,22 @@ func TestNewBasicAuth(t *testing.T) {
 	})
 
 	t.Run("should log a warning when credentials are malformed", func(t *testing.T) {
+		old := log.Writer()
+		defer log.SetOutput(old)
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+
 		filename := createBasicAuthFile(t, "foosdlijdgohdgdbar")
 
 		_, err := newBasicAuth(config.BasicAuth{
 			File: filename,
 		})
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
+		}
+		want := "[WARN] Error processing htpasswd file: malformed line, no colon: foosdlijdgohdgdbar"
+		if got := buf.String(); !strings.Contains(got, want) {
+			t.Fatalf("log does not contain expected:\nlog: %q\nexpected: %q", got, want)
 		}
 	})
 }

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -65,6 +65,11 @@ func createBasicAuth(t *testing.T, user string, password string) AuthScheme {
 	return basicAuth
 }
 
+func basicAuthHeader(username, password string) []string {
+	auth := []byte(username + ":" + password)
+	return []string{"Basic " + base64.StdEncoding.EncodeToString(auth)}
+}
+
 func TestNewBasicAuth(t *testing.T) {
 
 	t.Run("should create a basic auth scheme from the supplied config", func(t *testing.T) {
@@ -92,7 +97,6 @@ func TestNewBasicAuth(t *testing.T) {
 
 func TestBasic_Authorised(t *testing.T) {
 	basicAuth := createBasicAuth(t, "foo", "bar")
-	creds := []byte("foo:bar")
 
 	tests := []struct {
 		name string
@@ -104,7 +108,7 @@ func TestBasic_Authorised(t *testing.T) {
 			"correct credentials should be authorized",
 			&http.Request{
 				Header: http.Header{
-					"Authorization": []string{fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(creds))},
+					"Authorization": basicAuthHeader("foo", "bar"),
 				},
 			},
 			&responseWriter{},
@@ -114,7 +118,7 @@ func TestBasic_Authorised(t *testing.T) {
 			"incorrect credentials should not be authorized",
 			&http.Request{
 				Header: http.Header{
-					"Authorization": []string{fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("baz:blarg")))},
+					"Authorization": basicAuthHeader("baz", "blarg"),
 				},
 			},
 			&responseWriter{},
@@ -160,10 +164,9 @@ func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
 		t.Error(err)
 	}
 
-	creds := []byte("foo:bar")
 	r := &http.Request{
 		Header: http.Header{
-			"Authorization": []string{fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(creds))},
+			"Authorization": basicAuthHeader("foo", "bar"),
 		},
 	}
 


### PR DESCRIPTION
Hello @tristanmorgan,

while working on https://github.com/fabiolb/fabio/issues/1006 I did a detour on basic auth and found some possibilities to tidy up the tests.

Best reviewed commit-per-commit.

- auth/basic_test: booleans can be compared directly
- auth/basic_test: strings can be compared directly
- auth/basic_test: use self-describing names
- auth/basic_test: make test helpers idiomatic
- auth/basic_test: simplifications
- auth/basic_test: actually test the logs
