### PR TITLE
auth: tests: reduce runtime from 2.3 sec to 0.3 sec thanks to syncttest

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -7,10 +7,17 @@ import (
 	"github.com/fabiolb/fabio/config"
 )
 
+// AuthScheme defines an authentication scheme.
+// See
+// - docs/feature/authorization.md
+// - docs/ref/proxy.auth.md
 type AuthScheme interface {
+	// Authorized returns whether request satisfies the authorization scheme.
 	Authorized(request *http.Request, response http.ResponseWriter) bool
 }
 
+// LoadAuthSchemes takes the 'proxy.auth' configuration option and returns a map
+// auth name => auth implementation of a specific type.
 func LoadAuthSchemes(cfg map[string]config.AuthScheme) (map[string]AuthScheme, error) {
 	auths := map[string]AuthScheme{}
 	for _, a := range cfg {

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -11,12 +11,15 @@ import (
 	"github.com/tg123/go-htpasswd"
 )
 
-// basic is an implementation of AuthScheme
+// basic implements Basic HTTP Authentication.
+// It satisfies interface [AuthScheme].
 type basic struct {
 	secrets *htpasswd.File
 	realm   string
 }
 
+// newBasicAuth creates a [basic] authentication from cfg.
+// It might spawn a forever-running goroutine to periodically refresh the htpassd file.
 func newBasicAuth(cfg config.BasicAuth) (AuthScheme, error) {
 	bad := func(err error) {
 		log.Println("[WARN] Error processing htpasswd file:", err)
@@ -74,6 +77,7 @@ func newBasicAuth(cfg config.BasicAuth) (AuthScheme, error) {
 	}, nil
 }
 
+// Authorized returns whether request satisfies the authorization scheme.
 func (b *basic) Authorized(request *http.Request, response http.ResponseWriter) bool {
 	user, password, ok := request.BasicAuth()
 

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -16,6 +16,8 @@ import (
 type basic struct {
 	secrets *htpasswd.File
 	realm   string
+	//
+	done chan struct{} // USE ONLY FOR TESTING.
 }
 
 // newBasicAuth creates a [basic] authentication from cfg.
@@ -31,6 +33,7 @@ func newBasicAuth(cfg config.BasicAuth) (*basic, error) {
 	basicAuth := &basic{
 		secrets: secrets,
 		realm:   cfg.Realm,
+		done:    make(chan struct{}),
 	}
 	if cfg.Refresh == 0 {
 		// In this case the htpassd file will not be reloaded, we are done.
@@ -47,33 +50,39 @@ func newBasicAuth(cfg config.BasicAuth) (*basic, error) {
 
 	go func() {
 		cleared := false
-		ticker := time.NewTicker(cfg.Refresh).C
-		for range ticker {
-			stat, err := os.Stat(cfg.File)
-			if err != nil {
-				log.Println("[WARN] Error accessing htpasswd file:", err)
-				if !cleared {
-					err = secrets.ReloadFromReader(&bytes.Buffer{}, bad)
-					if err != nil {
-						log.Println("[WARN] Error clearing the htpasswd credentials:", err)
+		ticker := time.NewTicker(cfg.Refresh)
+		for {
+			select {
+			case <-ticker.C:
+				stat, err := os.Stat(cfg.File)
+				if err != nil {
+					log.Println("[WARN] Error accessing htpasswd file:", err)
+					if !cleared {
+						err = secrets.ReloadFromReader(&bytes.Buffer{}, bad)
+						if err != nil {
+							log.Println("[WARN] Error clearing the htpasswd credentials:", err)
+						} else {
+							log.Println("[INFO] The htpasswd credentials have been cleared")
+							cleared = true
+						}
+					}
+					continue
+				}
+				// refresh the htpasswd file only if its modification time has changed
+				// even if the new htpasswd file is older than previously loaded
+				if cfg.ModTime != stat.ModTime() {
+					if err := secrets.Reload(bad); err == nil {
+						log.Println("[INFO] The htpasswd file has been successfully reloaded")
+						cfg.ModTime = stat.ModTime()
+						cleared = false
 					} else {
-						log.Println("[INFO] The htpasswd credentials have been cleared")
-						cleared = true
+						log.Println("[WARN] Error reloading htpasswd file:", err)
 					}
 				}
-				continue
-			}
-
-			// refresh the htpasswd file only if its modification time has changed
-			// even if the new htpasswd file is older than previously loaded
-			if cfg.ModTime != stat.ModTime() {
-				if err := secrets.Reload(bad); err == nil {
-					log.Println("[INFO] The htpasswd file has been successfully reloaded")
-					cfg.ModTime = stat.ModTime()
-					cleared = false
-				} else {
-					log.Println("[WARN] Error reloading htpasswd file:", err)
-				}
+			// A ticker can be stopped but not closed, so we need another channel.
+			// USE ONLY FOR TESTING.
+			case <-basicAuth.done:
+				return
 			}
 		}
 	}()

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -20,7 +20,7 @@ type basic struct {
 
 // newBasicAuth creates a [basic] authentication from cfg.
 // It might spawn a forever-running goroutine to periodically refresh the htpassd file.
-func newBasicAuth(cfg config.BasicAuth) (AuthScheme, error) {
+func newBasicAuth(cfg config.BasicAuth) (*basic, error) {
 	bad := func(err error) {
 		log.Println("[WARN] Error processing htpasswd file:", err)
 	}

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -24,57 +24,61 @@ func newBasicAuth(cfg config.BasicAuth) (*basic, error) {
 	bad := func(err error) {
 		log.Println("[WARN] Error processing htpasswd file:", err)
 	}
-
 	secrets, err := htpasswd.New(cfg.File, htpasswd.DefaultSystems, bad)
 	if err != nil {
 		return nil, err
 	}
-
-	if cfg.Refresh > 0 {
-		stat, err := os.Stat(cfg.File)
-		if err != nil {
-			return nil, err
-		}
-		cfg.ModTime = stat.ModTime()
-
-		go func() {
-			cleared := false
-			ticker := time.NewTicker(cfg.Refresh).C
-			for range ticker {
-				stat, err := os.Stat(cfg.File)
-				if err != nil {
-					log.Println("[WARN] Error accessing htpasswd file:", err)
-					if !cleared {
-						err = secrets.ReloadFromReader(&bytes.Buffer{}, bad)
-						if err != nil {
-							log.Println("[WARN] Error clearing the htpasswd credentials:", err)
-						} else {
-							log.Println("[INFO] The htpasswd credentials have been cleared")
-							cleared = true
-						}
-					}
-					continue
-				}
-
-				// refresh the htpasswd file only if its modification time has changed
-				// even if the new htpasswd file is older than previously loaded
-				if cfg.ModTime != stat.ModTime() {
-					if err := secrets.Reload(bad); err == nil {
-						log.Println("[INFO] The htpasswd file has been successfully reloaded")
-						cfg.ModTime = stat.ModTime()
-						cleared = false
-					} else {
-						log.Println("[WARN] Error reloading htpasswd file:", err)
-					}
-				}
-			}
-		}()
-	}
-
-	return &basic{
+	basicAuth := &basic{
 		secrets: secrets,
 		realm:   cfg.Realm,
-	}, nil
+	}
+	if cfg.Refresh == 0 {
+		// In this case the htpassd file will not be reloaded, we are done.
+		return basicAuth, nil
+	}
+
+	// Prepare to reload the contents of the htpassd file each cfg.Refresh seconds.
+
+	stat, err := os.Stat(cfg.File)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ModTime = stat.ModTime()
+
+	go func() {
+		cleared := false
+		ticker := time.NewTicker(cfg.Refresh).C
+		for range ticker {
+			stat, err := os.Stat(cfg.File)
+			if err != nil {
+				log.Println("[WARN] Error accessing htpasswd file:", err)
+				if !cleared {
+					err = secrets.ReloadFromReader(&bytes.Buffer{}, bad)
+					if err != nil {
+						log.Println("[WARN] Error clearing the htpasswd credentials:", err)
+					} else {
+						log.Println("[INFO] The htpasswd credentials have been cleared")
+						cleared = true
+					}
+				}
+				continue
+			}
+
+			// refresh the htpasswd file only if its modification time has changed
+			// even if the new htpasswd file is older than previously loaded
+			if cfg.ModTime != stat.ModTime() {
+				if err := secrets.Reload(bad); err == nil {
+					log.Println("[INFO] The htpasswd file has been successfully reloaded")
+					cfg.ModTime = stat.ModTime()
+					cleared = false
+				} else {
+					log.Println("[WARN] Error reloading htpasswd file:", err)
+				}
+			}
+		}
+	}()
+
+	return basicAuth, nil
 }
 
 // Authorized returns whether request satisfies the authorization scheme.

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/fabiolb/fabio/config"
@@ -166,37 +167,46 @@ func TestBasic_Authorised(t *testing.T) {
 }
 
 func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
-	filename := createBasicAuthFile(t, "foo:bar")
+	synctest.Test(t, func(t *testing.T) {
+		filename := createBasicAuthFile(t, "foo:bar")
+		// We create a basic auth with periodic refresh.
+		basicAuth, err := newBasicAuth(config.BasicAuth{
+			File:    filename,
+			Refresh: time.Second,
+		})
+		if err != nil {
+			t.Error(err)
+		}
 
-	basicAuth, err := newBasicAuth(config.BasicAuth{
-		File:    filename,
-		Refresh: time.Second,
-	})
-	if err != nil {
-		t.Error(err)
-	}
+		r := &http.Request{
+			Header: http.Header{
+				"Authorization": basicAuthHeader("foo", "bar"),
+			},
+		}
+		w := &responseWriter{}
 
-	r := &http.Request{
-		Header: http.Header{
-			"Authorization": basicAuthHeader("foo", "bar"),
-		},
-	}
-
-	w := &responseWriter{}
-
-	t.Run("should authorize against supplied htpasswd file", func(t *testing.T) {
+		// We want the first call to Authorized() to succeed.
 		if got, want := basicAuth.Authorized(r, w), true; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}
-	})
 
-	if err := os.Remove(filename); err != nil {
-		t.Fatalf("removing htpasswd file: %s", err)
-	}
+		// Since refresh is enabled, removing the htpasswd file will cause the next
+		// call to Authorized() to fail, as documented.
+		if err := os.Remove(filename); err != nil {
+			t.Fatalf("removing htpasswd file: %s", err)
+		}
 
-	time.Sleep(2 * time.Second) // ensure htpasswd file refresh happened
-
-	t.Run("should not authorize after removing htpasswd file", func(t *testing.T) {
+		// Wait to ensure that the htpasswd file refresh happened.
+		// This happens within a syntest.Test(), so it will take zero time.
+		time.Sleep(2 * time.Second)
+		// Before exiting from the synctest bubble, we must terminate the basicAuth
+		// goroutine.
+		// We don't close the channel because closing is async. The send instead, since
+		// the channel is unbuffered, ensures that the test waits for the goroutine
+		// to receive and terminate.
+		basicAuth.done <- struct{}{}
+		synctest.Wait()
+		// We want the second call to Authorized() to fail.
 		if got, want := basicAuth.Authorized(r, w), false; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}


### PR DESCRIPTION
Hello @tristanmorgan,

This PR reduces the runtime of the auth tests from 2.3 sec to 0.3 sec thanks to `syncttest` :-)

On the other hand, due to `synctest` technicalities, I had to slightly modify also the production code, to allow the test code to require termination of the goroutine spawned by `newBasicAuth()`.

If you are not comfortable with this, I can understand.

Unfortunately the diff is confusing. Better reviewed commit-per-commit.

References:
- https://go.dev/blog/testing-time
- https://antonz.org/go-concurrency/testing/