### PR TITLE
Fix #1000: Support Proxy Protocol v2 ?

### DIFF
--- a/docs/content/cfg/_index.md
+++ b/docs/content/cfg/_index.md
@@ -31,7 +31,7 @@ Option                                     | Description
 `strip=/path`                              | Forward `/path/to/file` as `/to/file`
 `prepend=/prefix`                          | Forward `/path/to/file` as `/prefix/path/to/file`
 `proto=tcp`                                | Upstream service is TCP, `dst` must be `:port`
-`pxyproto=true`                            | Enables PROXY protocol on outbount TCP connection
+`pxyproto=true`                            | Enables outbound PROXY protocol v1 headers on a TCP connection
 `proto=https`                              | Upstream service is HTTPS
 `tlsskipverify=true`                       | Disable TLS cert validation for HTTPS upstream
 `host=name`                                | Set the `Host` header to `name`. If `name == 'dst'` then the `Host` header will be set to the registered upstream host name

--- a/docs/content/deploy/amazon-elb.md
+++ b/docs/content/deploy/amazon-elb.md
@@ -1,14 +1,16 @@
 ---
-title: "Amazon ELB"
+title: "Amazon ELB and NLB"
 weight: 400
 ---
 
-You can deploy fabio behind an Amazon ELB and enable [PROXY protocol support](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html) to get the remote address and port of the client.
+You can deploy fabio behind an Amazon Classic Load Balancer and enable [PROXY protocol support](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html) to pass the remote address and port of the client using version 1. For an Amazon Network Load Balancer (NLB), enable PROXY protocol v2 on the target group and set `pxyproto=true` on the fabio listener.
+
+The listener accepts either PROXY protocol version, so the same fabio routing configuration can be used with both load balancers.
 
 <pre>
-                                +- HTTP w/PROXY proto -> fabio -+-> service-a (host-a)
+                                +- HTTP/TCP w/PROXY v1 or v2 -> fabio -+-> service-a (host-a)
                                 |                               |
-internet -- HTTP/HTTPS --> ELB -+- HTTP w/PROXY proto -> fabio -+-> service-b (host-b)
+internet -- HTTP/HTTPS/TCP --> ELB or NLB -+- HTTP/TCP w/PROXY v1 or v2 -> fabio -+-> service-b (host-b)
                                 |                               |
-                                +- HTTP w/PROXY proto -> fabio -+-> service-c (host-c)
+                                +- HTTP/TCP w/PROXY v1 or v2 -> fabio -+-> service-c (host-c)
 </pre>

--- a/docs/content/feature/_index.md
+++ b/docs/content/feature/_index.md
@@ -22,7 +22,7 @@ Fabio supports the following:
  * [HTTPS TCP-SNI Proxy Support](/feature/https-tcp-sni-proxy/) - forward TLS connections based on hostname without re-encryption, or fallback to fabio terminating TLS and path routing as a fallback
  * [HTTPS Upstreams](/feature/https-upstream/) - forward requests to HTTPS upstream servers
  * [Metrics Support](/feature/metrics/) - support for Graphite, StatsD/DataDog and Circonus
- * [PROXY Protocol Support](/feature/proxy-protocol/) - support for HA Proxy PROXY protocol for inbound requests (use for Amazon ELB)
+ * [PROXY Protocol Support](/feature/proxy-protocol/) - support for HA Proxy PROXY protocol v1 and v2 for inbound requests (use with Amazon ELB or NLB)
  * [Server-Sent Events/SSE](/feature/sse/) - support for Server-Sent Events/SSE
  * [TCP dynamic proxy](/feature/tcp-dynamic-proxy/) - TCP proxy based on urlprefix tag
  * [TCP Proxy Support](/feature/tcp-proxy/) - raw TCP proxy support

--- a/docs/content/feature/proxy-protocol.md
+++ b/docs/content/feature/proxy-protocol.md
@@ -4,21 +4,24 @@ since: "1.1.3"
 ---
 
 fabio transparently supports the HA Proxy
-[PROXY protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) version 1
-which is used by HA Proxy,
-[Amazon ELB](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html)
-and others to transmit the remote address and port of the client without using headers.
+[PROXY protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) versions 1 and 2.
+These protocol versions transmit the remote address and port of the client
+without using headers. Version 1 is used by the Amazon Classic Load Balancer,
+while version 2 is used by the Amazon Network Load Balancer (NLB).
 
 You may control the behavior of PROXY protocol support with the following
 options on the listener:
 
-* `pxyproto`: When set to 'true' the listener will respect upstream v1
-  PROXY protocol headers.
+* `pxyproto`: When set to 'true' the listener will respect upstream PROXY
+  protocol version 1 or version 2 headers.
   NOTE: PROXY protocol was on by default from 1.1.3 to 1.5.10.
   This changed to off when this option was introduced with
   the 1.5.11 release.
   For more information about the PROXY protocol, please see:
   http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
+
+  This listener option is independent of the route option with the same name,
+  which writes version 1 headers to TCP upstream connections.
 
 * `pxytimeout`: Sets PROXY protocol header read timeout as a duration (e.g. '250ms').
   This defaults to 250ms if not set when 'pxyproto' is enabled.

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -47,7 +47,7 @@ and you need to add a separate `urlprefix-` tag for every `host/path` prefix the
 
 	# TCP examples
 	urlprefix-:3306 proto=tcp                          # route external port 3306
-	urlprefix-:3306 proto=tcp pxyproto=true            # enables PROXY protocol on outbount TCP connection
+	urlprefix-:3306 proto=tcp pxyproto=true            # enables outbound PROXY protocol v1 headers
 	
 	# GRPC/S examples
 	urlprefix-/my.service/Method proto=grpc                      # method specific route

--- a/docs/content/ref/proxy.addr.md
+++ b/docs/content/ref/proxy.addr.md
@@ -51,13 +51,16 @@ to the destination without decrypting the traffic.
   if no matching certificate was found. This matches the default
   behavior of the Go TLS server implementation.
 
-* `pxyproto`: When set to 'true' the listener will respect upstream v1
-  PROXY protocol headers.
+* `pxyproto`: When set to 'true' the listener will respect upstream PROXY
+  protocol version 1 or version 2 headers.
   NOTE: PROXY protocol was on by default from 1.1.3 to 1.5.10.
   This changed to off when this option was introduced with
   the 1.5.11 release.
   For more information about the PROXY protocol, please see:
   http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
+
+  This listener option is independent of the route option with the same name,
+  which writes version 1 headers to TCP upstream connections.
 
 * `pxytimeout`: Sets PROXY protocol header read timeout as a duration (e.g. '250ms').
   This defaults to 250ms if not set when `pxyproto` is enabled.

--- a/fabio.properties
+++ b/fabio.properties
@@ -234,13 +234,16 @@
 #                if no matching certificate was found. This matches the default
 #                behavior of the Go TLS server implementation.
 #
-#   pxyproto:    When set to 'true' the listener will respect upstream v1
-#                PROXY protocol headers.
+#   pxyproto:    When set to 'true' the listener will respect upstream PROXY
+#                protocol version 1 or version 2 headers.
 #                NOTE: PROXY protocol was on by default from 1.1.3 to 1.5.10.
 #                This changed to off when this option was introduced with
 #                the 1.5.11 release.
 #                For more information about the PROXY protocol, please see:
 #                http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
+#                This listener option is independent of the route option with
+#                the same name, which writes version 1 headers to TCP upstream
+#                connections.
 #
 #   pxytimeout:  Sets PROXY protocol header read timeout as a duration (e.g. '250ms').
 #                This defaults to 250ms if not set when 'pxyproto' is enabled.

--- a/proxy/inetaf_tcpproxy_integration_test.go
+++ b/proxy/inetaf_tcpproxy_integration_test.go
@@ -173,7 +173,6 @@ route add tcproute example2.com/ tcp://%s opts "proto=tcp"`
 // consumes the PROXY header before tcpproxy inspects the TLS ClientHello.
 func TestProxyHTTPSTCPSNIWithProxyProto(t *testing.T) {
 	for _, version := range proxyProtoVersions {
-		version := version
 		t.Run(version.name, func(t *testing.T) {
 			srv := tcptest.NewTLSServerWithProxyProto(proxyHandler)
 			defer srv.Close()

--- a/proxy/inetaf_tcpproxy_integration_test.go
+++ b/proxy/inetaf_tcpproxy_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"slices"
 	"testing"
@@ -166,6 +167,54 @@ route add tcproute example2.com/ tcp://%s opts "proto=tcp"`
 		})
 	}
 
+}
+
+// TestProxyHTTPSTCPSNIWithProxyProto verifies that the combined listener
+// consumes the PROXY header before tcpproxy inspects the TLS ClientHello.
+func TestProxyHTTPSTCPSNIWithProxyProto(t *testing.T) {
+	for _, version := range proxyProtoVersions {
+		version := version
+		t.Run(version.name, func(t *testing.T) {
+			srv := tcptest.NewTLSServerWithProxyProto(proxyHandler)
+			defer srv.Close()
+
+			tmp, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("net.Listen: %v", err)
+			}
+			proxyAddr := tmp.Addr().String()
+			tmp.Close()
+
+			tp := &tcp.SNIProxy{
+				Lookup: func(string) *route.Target {
+					return &route.Target{URL: &url.URL{Host: srv.Addr}, ProxyProto: true}
+				},
+			}
+			matcher := func(_ context.Context, host string) bool {
+				return host == "example.com"
+			}
+			go func() {
+				l := config.Listen{Addr: proxyAddr, ProxyProto: true}
+				if err := ListenAndServeHTTPSTCPSNI(l, okHandler, tp, tlsServerConfig(), matcher); err != nil {
+					t.Logf("ListenAndServeHTTPSTCPSNI: %v", err)
+				}
+			}()
+			defer Close()
+
+			cfg := tlsClientConfig()
+			cfg.ServerName = "example.com"
+			dialer := tcptest.NewTLSRetryDialer(cfg)
+			dialer.ProxyProto = true
+			dialer.ProxyProtoVersion = version.version
+			out, err := dialer.Dial("tcp", proxyAddr)
+			if err != nil {
+				t.Fatalf("tls.Dial: %#v", err)
+			}
+			defer out.Close()
+
+			testProxyProto(t, out)
+		})
+	}
 }
 
 func foundDNSName(crt *x509.Certificate, dnsName string) bool {

--- a/proxy/serve.go
+++ b/proxy/serve.go
@@ -17,7 +17,6 @@ import (
 	"github.com/fabiolb/fabio/proxy/tcp"
 
 	"github.com/inetaf/tcpproxy"
-	"github.com/pires/go-proxyproto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -120,9 +119,9 @@ func ListenAndServePrometheus(l config.Listen, pcfg config.Prometheus, cfg *tls.
 }
 
 func ListenAndServeHTTPSTCPSNI(l config.Listen, h http.Handler, p tcp.Handler, cfg *tls.Config, m tcpproxy.Matcher) error {
-	// we only want proxy proto enabled on tcp proxies
-	pxyProto := l.ProxyProto
-	l.ProxyProto = false
+	// PROXY protocol must be consumed before tcpproxy inspects the TLS
+	// ClientHello for SNI routing. ListenTCP applies the configured wrapper to
+	// the listener before tcpproxy sees any connections.
 	tp := &tcpproxy.Proxy{
 		ListenFunc: func(net, laddr string) (net.Listener, error) {
 			// cfg is nil here so it's not terminating TLS (yet)
@@ -145,15 +144,7 @@ func ListenAndServeHTTPSTCPSNI(l config.Listen, h http.Handler, p tcp.Handler, c
 	}
 
 	tps := &InetAfTCPProxyServer{Proxy: tp}
-	var tln net.Listener = tcpSNIListener
-	// enable proxy protocol on the tcp side if configured to do so
-	if pxyProto {
-		tln = &proxyproto.Listener{
-			Listener:          tln,
-			ReadHeaderTimeout: l.ProxyHeaderTimeout,
-		}
-	}
-	tps.ServeLater(tln, &tcp.Server{
+	tps.ServeLater(tcpSNIListener, &tcp.Server{
 		Addr:         l.Addr,
 		Handler:      p,
 		ReadTimeout:  l.ReadTimeout,

--- a/proxy/tcp/tcptest/dialer.go
+++ b/proxy/tcp/tcptest/dialer.go
@@ -2,8 +2,19 @@ package tcptest
 
 import (
 	"crypto/tls"
+	"encoding/binary"
+	"io"
 	"net"
 	"time"
+)
+
+// ProxyProtoVersion identifies the PROXY protocol version written by a test
+// dialer. A zero value retains the existing v1 behavior.
+type ProxyProtoVersion uint8
+
+const (
+	ProxyProtoVersion1 ProxyProtoVersion = 1
+	ProxyProtoVersion2 ProxyProtoVersion = 2
 )
 
 type Dialer interface {
@@ -18,10 +29,11 @@ func NewRetryDialer() *RetryDialer {
 // the timeout has been reached. The default timeout is one
 // second and the default sleep interval is 100ms.
 type RetryDialer struct {
-	Dialer     net.Dialer
-	Timeout    time.Duration
-	Sleep      time.Duration
-	ProxyProto bool
+	Dialer            net.Dialer
+	Timeout           time.Duration
+	Sleep             time.Duration
+	ProxyProto        bool
+	ProxyProtoVersion ProxyProtoVersion
 }
 
 func (d *RetryDialer) Dial(network, addr string) (c net.Conn, err error) {
@@ -31,8 +43,7 @@ func (d *RetryDialer) Dial(network, addr string) (c net.Conn, err error) {
 			return nil, err
 		}
 		if d.ProxyProto {
-			pxy := "PROXY TCP4 1.2.3.4 5.6.7.8 12345 54321\r\n"
-			_, err = conn.Write([]byte(pxy))
+			err = writeProxyProtoHeader(conn, d.ProxyProtoVersion)
 		}
 		return conn, err
 	}
@@ -44,11 +55,12 @@ func NewTLSRetryDialer(cfg *tls.Config) *TLSRetryDialer {
 }
 
 type TLSRetryDialer struct {
-	TLS        *tls.Config
-	Dialer     net.Dialer
-	Timeout    time.Duration
-	Sleep      time.Duration
-	ProxyProto bool
+	TLS               *tls.Config
+	Dialer            net.Dialer
+	Timeout           time.Duration
+	Sleep             time.Duration
+	ProxyProto        bool
+	ProxyProtoVersion ProxyProtoVersion
 }
 
 func (d *TLSRetryDialer) Dial(network, addr string) (c net.Conn, err error) {
@@ -58,12 +70,44 @@ func (d *TLSRetryDialer) Dial(network, addr string) (c net.Conn, err error) {
 			return nil, err
 		}
 		if d.ProxyProto {
-			pxy := "PROXY TCP4 1.2.3.4 5.6.7.8 12345 54321\r\n"
-			_, err = conn.Write([]byte(pxy))
+			err = writeProxyProtoHeader(conn, d.ProxyProtoVersion)
 		}
 		return tls.Client(conn, d.TLS), err
 	}
 	return retry(dial, d.Timeout, d.Sleep)
+}
+
+func writeProxyProtoHeader(conn net.Conn, version ProxyProtoVersion) error {
+	header := proxyProtoHeader(version)
+	n, err := conn.Write(header)
+	if err != nil {
+		return err
+	}
+	if n != len(header) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func proxyProtoHeader(version ProxyProtoVersion) []byte {
+	if version != ProxyProtoVersion2 {
+		return []byte("PROXY TCP4 1.2.3.4 5.6.7.8 12345 54321\r\n")
+	}
+
+	// This v2 fixture is intentionally assembled without go-proxyproto so the
+	// integration tests exercise the parser against the wire representation.
+	header := make([]byte, 28)
+	copy(header, []byte{
+		0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51,
+		0x55, 0x49, 0x54, 0x0a,
+		0x21, 0x11, // version 2, PROXY command, TCP over IPv4
+	})
+	binary.BigEndian.PutUint16(header[14:16], 12)
+	copy(header[16:20], []byte{1, 2, 3, 4})
+	copy(header[20:24], []byte{5, 6, 7, 8})
+	binary.BigEndian.PutUint16(header[24:26], 12345)
+	binary.BigEndian.PutUint16(header[26:28], 54321)
+	return header
 }
 
 type dialer func() (net.Conn, error)

--- a/proxy/tcp_integration_test.go
+++ b/proxy/tcp_integration_test.go
@@ -240,154 +240,179 @@ var proxyHandler tcp.HandlerFunc = func(c net.Conn) error {
 	return err
 }
 
-// TestTCPProxyWithProxyProtoEnables tests proxying an unencrypted TCP connection
-// to a TCP upstream server with proxy protocol enabed on upstream connection
+var proxyProtoVersions = []struct {
+	name    string
+	version tcptest.ProxyProtoVersion
+}{
+	{name: "v1", version: tcptest.ProxyProtoVersion1},
+	{name: "v2", version: tcptest.ProxyProtoVersion2},
+}
+
+// TestTCPProxyWithProxyProto tests proxying an unencrypted TCP connection
+// to a TCP upstream server with proxy protocol enabled on the upstream connection.
 func TestTCPProxyWithProxyProto(t *testing.T) {
-	srv := tcptest.NewServerWithProxyProto(proxyHandler)
-	defer srv.Close()
+	for _, version := range proxyProtoVersions {
+		version := version
+		t.Run(version.name, func(t *testing.T) {
+			srv := tcptest.NewServerWithProxyProto(proxyHandler)
+			defer srv.Close()
 
-	// start proxy
-	proxyAddr := "127.0.0.1:57778"
-	go func() {
-		h := &tcp.Proxy{
-			Lookup: func(h string) *route.Target {
-				tbl, _ := route.NewTable(bytes.NewBufferString("route add srv :57778 tcp://" + srv.Addr + " opts \"pxyproto=true\""))
-				return tbl.LookupHost(h, route.Picker["rr"])
-			},
-		}
-		l := config.Listen{Addr: proxyAddr, ProxyProto: true}
-		if err := ListenAndServeTCP(l, h, nil); err != nil {
-			t.Log("ListenAndServeTCP: ", err)
-		}
-	}()
-	defer Close()
+			// start proxy
+			proxyAddr := "127.0.0.1:57778"
+			go func() {
+				h := &tcp.Proxy{
+					Lookup: func(h string) *route.Target {
+						tbl, _ := route.NewTable(bytes.NewBufferString("route add srv :57778 tcp://" + srv.Addr + " opts \"pxyproto=true\""))
+						return tbl.LookupHost(h, route.Picker["rr"])
+					},
+				}
+				l := config.Listen{Addr: proxyAddr, ProxyProto: true}
+				if err := ListenAndServeTCP(l, h, nil); err != nil {
+					t.Log("ListenAndServeTCP: ", err)
+				}
+			}()
+			defer Close()
 
-	// connect to proxy
-	dialer := tcptest.NewRetryDialer()
-	dialer.ProxyProto = true
-	out, err := dialer.Dial("tcp", proxyAddr)
-	if err != nil {
-		t.Fatalf("net.Dial: %#v", err)
+			// connect to proxy
+			dialer := tcptest.NewRetryDialer()
+			dialer.ProxyProto = true
+			dialer.ProxyProtoVersion = version.version
+			out, err := dialer.Dial("tcp", proxyAddr)
+			if err != nil {
+				t.Fatalf("net.Dial: %#v", err)
+			}
+			defer out.Close()
+
+			testProxyProto(t, out)
+		})
 	}
-	defer out.Close()
-
-	testProxyProto(t, out)
 }
 
 // TestTCPProxyWithTLSWithProxyProto tests proxying an encrypted TCP connection
 // to an unencrypted upstream TCP server with proxy protocol enabled.
 // The proxy extract the proxy protocol header and terminates the TLS connection.
 func TestTCPProxyWithTLSWithProxyProto(t *testing.T) {
-	srv := tcptest.NewServerWithProxyProto(proxyHandler)
-	defer srv.Close()
+	for _, version := range proxyProtoVersions {
+		version := version
+		t.Run(version.name, func(t *testing.T) {
+			srv := tcptest.NewServerWithProxyProto(proxyHandler)
+			defer srv.Close()
 
-	// setup cert source
-	dir := t.TempDir()
+			// setup cert source
+			dir := t.TempDir()
 
-	mustWrite := func(name string, data []byte) {
-		path := filepath.Join(dir, name)
-		if err := os.WriteFile(path, data, 0644); err != nil {
-			t.Fatalf("os.WriteFile: %s", err)
-		}
-	}
-	mustWrite("example.com-key.pem", internal.LocalhostKey)
-	mustWrite("example.com-cert.pem", internal.LocalhostCert)
-
-	// start tcp proxy
-	proxyAddr := "127.0.0.1:57779"
-	cs := config.CertSource{Name: "cs", Type: "path", CertPath: dir}
-	src, err := cert.NewSource(cs)
-	if err != nil {
-		t.Fatal("cert.NewSource: ", err)
-	}
-	tlscfg, err := cert.TLSConfig(src, false, 0, 0, nil)
-	if err != nil {
-		t.Fatal("cert.TLSConfig: ", err)
-	}
-	go func() {
-
-		h := &tcp.Proxy{
-			Lookup: func(string) *route.Target {
-				return &route.Target{URL: &url.URL{Host: srv.Addr}, ProxyProto: true}
-			},
-		}
-
-		l := config.Listen{Addr: proxyAddr, ProxyProto: true}
-		if err := ListenAndServeTCP(l, h, tlscfg); err != nil {
-			// closing the listener returns this error from the accept loop
-			// which we can ignore.
-			if err.Error() != "accept tcp 127.0.0.1:57779: use of closed network connection" {
-				t.Log("ListenAndServeTCP: ", err)
+			mustWrite := func(name string, data []byte) {
+				path := filepath.Join(dir, name)
+				if err := os.WriteFile(path, data, 0644); err != nil {
+					t.Fatalf("os.WriteFile: %s", err)
+				}
 			}
-		}
-	}()
-	defer Close()
+			mustWrite("example.com-key.pem", internal.LocalhostKey)
+			mustWrite("example.com-cert.pem", internal.LocalhostCert)
 
-	// give cert store some time to pick up certs
-	time.Sleep(250 * time.Millisecond)
+			// start tcp proxy
+			proxyAddr := "127.0.0.1:57779"
+			cs := config.CertSource{Name: "cs", Type: "path", CertPath: dir}
+			src, err := cert.NewSource(cs)
+			if err != nil {
+				t.Fatal("cert.NewSource: ", err)
+			}
+			tlscfg, err := cert.TLSConfig(src, false, 0, 0, nil)
+			if err != nil {
+				t.Fatal("cert.TLSConfig: ", err)
+			}
+			go func() {
+				h := &tcp.Proxy{
+					Lookup: func(string) *route.Target {
+						return &route.Target{URL: &url.URL{Host: srv.Addr}, ProxyProto: true}
+					},
+				}
 
-	rootCAs := x509.NewCertPool()
-	if ok := rootCAs.AppendCertsFromPEM(internal.LocalhostCert); !ok {
-		t.Fatal("could not parse cert")
+				l := config.Listen{Addr: proxyAddr, ProxyProto: true}
+				if err := ListenAndServeTCP(l, h, tlscfg); err != nil {
+					// closing the listener returns this error from the accept loop
+					// which we can ignore.
+					if err.Error() != "accept tcp 127.0.0.1:57779: use of closed network connection" {
+						t.Log("ListenAndServeTCP: ", err)
+					}
+				}
+			}()
+			defer Close()
+
+			// give cert store some time to pick up certs
+			time.Sleep(250 * time.Millisecond)
+
+			rootCAs := x509.NewCertPool()
+			if ok := rootCAs.AppendCertsFromPEM(internal.LocalhostCert); !ok {
+				t.Fatal("could not parse cert")
+			}
+			cfg := &tls.Config{
+				RootCAs:    rootCAs,
+				ServerName: "example.com",
+			}
+
+			// connect to proxy
+			dialer := tcptest.NewTLSRetryDialer(cfg)
+			dialer.ProxyProto = true
+			dialer.ProxyProtoVersion = version.version
+			out, err := dialer.Dial("tcp", proxyAddr)
+			if err != nil {
+				t.Fatalf("tls.Dial: %#v", err)
+			}
+			defer out.Close()
+
+			testProxyProto(t, out)
+		})
 	}
-	cfg := &tls.Config{
-		RootCAs:    rootCAs,
-		ServerName: "example.com",
-	}
-
-	// connect to proxy
-	dialer := tcptest.NewTLSRetryDialer(cfg)
-	dialer.ProxyProto = true
-	out, err := dialer.Dial("tcp", proxyAddr)
-	if err != nil {
-		t.Fatalf("tls.Dial: %#v", err)
-	}
-	defer out.Close()
-
-	testProxyProto(t, out)
 }
 
 // TestTCPSNIProxyWithProxyProto tests proxying an encrypted TCP connection adding
 // proxy protocol header to an upstream TCP service without decrypting the traffic.
 // The upstream server extracts the proxy protocol and terminates the TLS connection.
 func TestTCPSNIProxyWithProxyProto(t *testing.T) {
-	srv := tcptest.NewTLSServerWithProxyProto(proxyHandler)
-	defer srv.Close()
+	for _, version := range proxyProtoVersions {
+		version := version
+		t.Run(version.name, func(t *testing.T) {
+			srv := tcptest.NewTLSServerWithProxyProto(proxyHandler)
+			defer srv.Close()
 
-	// start tcp proxy
-	proxyAddr := "127.0.0.1:57778"
-	go func() {
-		h := &tcp.SNIProxy{
-			Lookup: func(string) *route.Target {
-				return &route.Target{URL: &url.URL{Host: srv.Addr}, ProxyProto: true}
-			},
-		}
-		l := config.Listen{Addr: proxyAddr, ProxyProto: true}
-		if err := ListenAndServeTCP(l, h, nil); err != nil {
-			t.Log("ListenAndServeTCP: ", err)
-		}
-	}()
-	defer Close()
+			// start tcp proxy
+			proxyAddr := "127.0.0.1:57778"
+			go func() {
+				h := &tcp.SNIProxy{
+					Lookup: func(string) *route.Target {
+						return &route.Target{URL: &url.URL{Host: srv.Addr}, ProxyProto: true}
+					},
+				}
+				l := config.Listen{Addr: proxyAddr, ProxyProto: true}
+				if err := ListenAndServeTCP(l, h, nil); err != nil {
+					t.Log("ListenAndServeTCP: ", err)
+				}
+			}()
+			defer Close()
 
-	rootCAs := x509.NewCertPool()
-	if ok := rootCAs.AppendCertsFromPEM(internal.LocalhostCert); !ok {
-		t.Fatal("could not parse cert")
+			rootCAs := x509.NewCertPool()
+			if ok := rootCAs.AppendCertsFromPEM(internal.LocalhostCert); !ok {
+				t.Fatal("could not parse cert")
+			}
+			cfg := &tls.Config{
+				RootCAs:    rootCAs,
+				ServerName: "example.com",
+			}
+
+			// connect to proxy
+			dialer := tcptest.NewTLSRetryDialer(cfg)
+			dialer.ProxyProto = true
+			dialer.ProxyProtoVersion = version.version
+			out, err := dialer.Dial("tcp", proxyAddr)
+			if err != nil {
+				t.Fatalf("tls.Dial: %#v", err)
+			}
+			defer out.Close()
+
+			testProxyProto(t, out)
+		})
 	}
-	cfg := &tls.Config{
-		RootCAs:    rootCAs,
-		ServerName: "example.com",
-	}
-
-	// connect to proxy
-	dialer := tcptest.NewTLSRetryDialer(cfg)
-	dialer.ProxyProto = true
-	out, err := dialer.Dial("tcp", proxyAddr)
-	if err != nil {
-		t.Fatalf("tls.Dial: %#v", err)
-	}
-	defer out.Close()
-
-	testProxyProto(t, out)
 }
 
 func testProxyProto(t *testing.T, c net.Conn) {

--- a/proxy/tcp_integration_test.go
+++ b/proxy/tcp_integration_test.go
@@ -252,7 +252,6 @@ var proxyProtoVersions = []struct {
 // to a TCP upstream server with proxy protocol enabled on the upstream connection.
 func TestTCPProxyWithProxyProto(t *testing.T) {
 	for _, version := range proxyProtoVersions {
-		version := version
 		t.Run(version.name, func(t *testing.T) {
 			srv := tcptest.NewServerWithProxyProto(proxyHandler)
 			defer srv.Close()
@@ -293,7 +292,6 @@ func TestTCPProxyWithProxyProto(t *testing.T) {
 // The proxy extract the proxy protocol header and terminates the TLS connection.
 func TestTCPProxyWithTLSWithProxyProto(t *testing.T) {
 	for _, version := range proxyProtoVersions {
-		version := version
 		t.Run(version.name, func(t *testing.T) {
 			srv := tcptest.NewServerWithProxyProto(proxyHandler)
 			defer srv.Close()
@@ -371,7 +369,6 @@ func TestTCPProxyWithTLSWithProxyProto(t *testing.T) {
 // The upstream server extracts the proxy protocol and terminates the TLS connection.
 func TestTCPSNIProxyWithProxyProto(t *testing.T) {
 	for _, version := range proxyProtoVersions {
-		version := version
 		t.Run(version.name, func(t *testing.T) {
 			srv := tcptest.NewTLSServerWithProxyProto(proxyHandler)
 			defer srv.Close()


### PR DESCRIPTION
Fixes #1000

## Implementation summary

Added inbound PROXY v2 coverage, fixed parsing before SNI routing, and documented v1/v2 plus AWS NLB usage.

## Changes

```
docs/content/cfg/_index.md                |   2 +-
 docs/content/deploy/amazon-elb.md         |  12 +-
 docs/content/feature/_index.md            |   2 +-
 docs/content/feature/proxy-protocol.md    |  15 +-
 docs/content/quickstart/_index.md         |   2 +-
 docs/content/ref/proxy.addr.md            |   7 +-
 fabio.properties                          |   7 +-
 proxy/inetaf_tcpproxy_integration_test.go |  49 ++++++
 proxy/serve.go                            |  17 +-
 proxy/tcp/tcptest/dialer.go               |  70 ++++++--
 proxy/tcp_integration_test.go             | 269 ++++++++++++++++--------------
 11 files changed, 286 insertions(+), 166 deletions(-)
```

## Testing

Yes. Relevant repository checks passed.