### PR TITLE
fix: bgp: build and run test only on linux

### DIFF
--- a/bgp/bgp.go
+++ b/bgp/bgp.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package bgp
 

--- a/bgp/bgp_test.go
+++ b/bgp/bgp_test.go
@@ -1,21 +1,22 @@
-//go:build !windows
+//go:build linux
 
 package bgp
 
 import (
 	"context"
 	"encoding/json"
-	"github.com/fabiolb/fabio/config"
-	api "github.com/osrg/gobgp/v4/api"
-	"github.com/osrg/gobgp/v4/pkg/apiutil"
-	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
-	"github.com/osrg/gobgp/v4/pkg/server"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/fabiolb/fabio/config"
+	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"github.com/osrg/gobgp/v4/pkg/server"
 )
 
 // bgpTestParams describes one peering scenario.  The gobgpd side is

--- a/bgp/bgp_unsupported.go
+++ b/bgp/bgp_unsupported.go
@@ -1,7 +1,10 @@
+//go:build !linux
+
 package bgp
 
 import (
 	"errors"
+
 	"github.com/fabiolb/fabio/config"
 )
 


### PR DESCRIPTION
Before the update to bgp v4 (#1042), it was at least possible to run the bgp tests on macos.

Now. also after having installed a custom build of github.com/osrg/gobgp/v4/cmd/gobgpd
and github.com/osrg/gobgp/v4/cmd/gobgp, they fail as reported below.

This commit allows at least to run the tests for the Fabio project without failures, by disabling the build and test of bgp on any OS not linux.

To make the file names mean something, I also renamed them as follows:

    bgp_nonwindows.go      => bgp.go
    bgp_nonwindows_test.go => bgp_test.go
    bgp_windows.go         => bgp_unsupported.go

This is still non optimal, in the sense that for example we don't build bgp for freebsd, while it probably would work. On the other hand, the fix would be simply to add the missing build tag to the existing files.


Tests failures on darwin:

    $ go test ./bgp
    2026/09/01 21:02:49 [INFO] gobgpd shutting down Topic=>BgpServer
    2026/09/01 21:02:49 [WARN] gobgpd listen failed Topic=>grpc Key=>127.0.0.2:50051 Error=>listen tcp 127.0.0.2:50051: bind: can't assign requested address
    2026/09/01 21:02:49 [ERROR] gobgpd failed to listen grpc port Error=>listen tcp 127.0.0.2:50051: bind: can't assign requested address
    2026/09/01 21:02:49 [WARN] gobgpd listen failed Topic=>grpc Key=>127.0.0.4:50051 Error=>listen tcp 127.0.0.4:50051: bind: can't assign requested address
    2026/09/01 21:02:49 [ERROR] gobgpd failed to listen grpc port Error=>listen tcp 127.0.0.4:50051: bind: can't assign requested address
    2026/09/01 21:02:49 [INFO] gobgpd shutting down Topic=>BgpServer
    --- FAIL: TestBGPHandler (0.01s)
        --- FAIL: TestBGPHandler/ebgp (0.00s)
            bgp_nonwindows_test.go:111: error starting BGP: listen tcp4 127.0.0.2:1790: bind: can't assign requested address
        --- FAIL: TestBGPHandler/ibgp (0.00s)
            bgp_nonwindows_test.go:111: error starting BGP: listen tcp4 127.0.0.4:1791: bind: can't assign requested address
    2026/09/01 21:02:49 [INFO] gobgpd shutting down Topic=>BgpServer
    --- FAIL: TestGOBGPDConfigFile (0.00s)
        bgp_nonwindows_test.go:307: error applying gobgpd config file: bgp: error initializing from gobgp config: listen tcp4 127.0.0.6:1793: bind: can't assign requested address
    2026/09/01 21:02:49 [INFO] gobgpd shutting down Topic=>BgpServer
    --- FAIL: TestAddRoutesFamilies (0.00s)
        bgp_nonwindows_test.go:350: error starting BGP: listen tcp4 127.0.0.8:1794: bind: can't assign requested address