### PR TITLE
Question about X-Forwarded-Proto

### DIFF
--- a/proxy/http_handler.go
+++ b/proxy/http_handler.go
@@ -32,9 +32,13 @@ func newHTTPProxy(target *url.URL, tr http.RoundTripper, flush time.Duration) ht
 				req.Out.Header.Set("X-Forwarded-For", xff)
 			}
 
-			// SetXForwarded will handle X-Forwarded-For (append), X-Forwarded-Host, and X-Forwarded-Proto
-			// Other headers (X-Forwarded-Port, X-Forwarded-Prefix, Forwarded) are already set by addHeaders()
+			// SetXForwarded handles X-Forwarded-For (append) and X-Forwarded-Host,
+			// but derives X-Forwarded-Proto from the direct connection. Preserve the
+			// protocol already resolved by addHeaders(), including one from an upstream proxy.
 			req.SetXForwarded()
+			if xfp := req.In.Header.Get("X-Forwarded-Proto"); xfp != "" {
+				req.Out.Header.Set("X-Forwarded-Proto", xfp)
+			}
 		},
 		FlushInterval: flush,
 		Transport:     tr,

--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -102,6 +102,44 @@ func TestProxyProducesCorrectXForwardedSomethingHeader(t *testing.T) {
 	}
 }
 
+func TestProxyPreservesXForwardedProto(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.Header.Get("X-Forwarded-Proto"))
+	}))
+	defer server.Close()
+
+	proxy := httptest.NewServer(&HTTPProxy{
+		Transport: http.DefaultTransport,
+		Lookup: func(r *http.Request) *route.Target {
+			return &route.Target{URL: mustParse(server.URL)}
+		},
+	})
+	defer proxy.Close()
+
+	tests := []struct {
+		name           string
+		forwardedProto string
+		want           string
+	}{
+		{name: "preserve forwarded https", forwardedProto: "https", want: "https"},
+		{name: "set direct http", want: "http"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", proxy.URL, nil)
+			if tt.forwardedProto != "" {
+				req.Header.Set("X-Forwarded-Proto", tt.forwardedProto)
+			}
+
+			_, body := mustDo(req)
+			if got := string(body); got != tt.want {
+				t.Errorf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProxyRequestIDHeader(t *testing.T) {
 	got := "not called"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
Preserve the protocol already resolved by `addHeaders` after `ReverseProxy.SetXForwarded`, so TLS terminated by an upstream proxy can continue to reach backends as `X-Forwarded-Proto: https` even when Fabio receives the connection over HTTP.

## Changes
- Reapply the resolved inbound `X-Forwarded-Proto` after `SetXForwarded` while retaining the existing X-Forwarded-For append and X-Forwarded-Host behavior.
- Add integration coverage for forwarded HTTPS and the normal direct HTTP default.

## Testing
The focused regression test and the full proxy package test suite pass.

Fixes #957