### PR TITLE
Support for authentication middleware (eg: oauth2-proxy) ?

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,13 +12,20 @@ import (
 // - docs/feature/authorization.md
 // - docs/ref/proxy.auth.md
 type AuthScheme interface {
-	// Authorized returns whether request satisfies the authorization scheme.
-	Authorized(request *http.Request, response http.ResponseWriter) bool
+	// Authorized returns the authorization decision for request.
+	Authorized(request *http.Request, response http.ResponseWriter) AuthDecision
+}
+
+// AuthDecision describes whether a request is authorized and whether the
+// authentication scheme already completed the client response.
+type AuthDecision struct {
+	Authorized bool
+	Done       bool
 }
 
 // LoadAuthSchemes takes the 'proxy.auth' configuration option and returns a map
 // auth name => auth implementation of a specific type.
-func LoadAuthSchemes(cfg map[string]config.AuthScheme) (map[string]AuthScheme, error) {
+func LoadAuthSchemes(cfg map[string]config.AuthScheme, client *http.Client) (map[string]AuthScheme, error) {
 	auths := map[string]AuthScheme{}
 	for _, a := range cfg {
 		switch a.Type {
@@ -28,6 +35,12 @@ func LoadAuthSchemes(cfg map[string]config.AuthScheme) (map[string]AuthScheme, e
 				return nil, err
 			}
 			auths[a.Name] = b
+		case "external":
+			e, err := newExternalAuth(a.External, client)
+			if err != nil {
+				return nil, err
+			}
+			auths[a.Name] = e
 		default:
 			return nil, fmt.Errorf("unknown auth type '%s'", a.Type)
 		}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -17,7 +17,7 @@ func TestLoadAuthSchemes(t *testing.T) {
 					File: "/some/non/existent/file",
 				},
 			},
-		})
+		}, nil)
 
 		const errorText = "open /some/non/existent/file: no such file or directory"
 
@@ -32,7 +32,7 @@ func TestLoadAuthSchemes(t *testing.T) {
 				Name: "myauth",
 				Type: "foo",
 			},
-		})
+		}, nil)
 
 		const errorText = "unknown auth type 'foo'"
 
@@ -60,7 +60,7 @@ func TestLoadAuthSchemes(t *testing.T) {
 					File: myotherauth,
 				},
 			},
-		})
+		}, nil)
 
 		if len(result) != 2 {
 			t.Fatalf("expected 2 auth schemes, got %d", len(result))

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -91,13 +91,13 @@ func newBasicAuth(cfg config.BasicAuth) (*basic, error) {
 }
 
 // Authorized returns whether request satisfies the authorization scheme.
-func (b *basic) Authorized(request *http.Request, response http.ResponseWriter) bool {
+func (b *basic) Authorized(request *http.Request, response http.ResponseWriter) AuthDecision {
 	user, password, ok := request.BasicAuth()
 
 	if !ok {
 		response.Header().Set("WWW-Authenticate", "Basic realm=\""+b.realm+"\"")
-		return false
+		return AuthDecision{}
 	}
 
-	return b.secrets.Match(user, password)
+	return AuthDecision{Authorized: b.secrets.Match(user, password)}
 }

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -159,7 +159,7 @@ func TestBasic_Authorised(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := basicAuth.Authorized(tt.req, tt.res); got != tt.want {
+			if got := basicAuth.Authorized(tt.req, tt.res).Authorized; got != tt.want {
 				t.Errorf("got %v want %v", got, tt.want)
 			}
 		})
@@ -186,7 +186,7 @@ func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
 		w := &responseWriter{}
 
 		// We want the first call to Authorized() to succeed.
-		if got, want := basicAuth.Authorized(r, w), true; got != want {
+		if got, want := basicAuth.Authorized(r, w).Authorized, true; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}
 
@@ -207,7 +207,7 @@ func TestBasic_Authorised_should_fail_without_htpasswd_file(t *testing.T) {
 		basicAuth.done <- struct{}{}
 		synctest.Wait()
 		// We want the second call to Authorized() to fail.
-		if got, want := basicAuth.Authorized(r, w), false; got != want {
+		if got, want := basicAuth.Authorized(r, w).Authorized, false; got != want {
 			t.Errorf("got %v want %v", got, want)
 		}
 	})

--- a/auth/external.go
+++ b/auth/external.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/fabiolb/fabio/config"
+)
+
+type external struct {
+	client            *http.Client
+	endpoint          string
+	setAuthHeaders    []string
+	appendAuthHeaders []string
+}
+
+func newExternalAuth(cfg config.ExternalAuth, client *http.Client) (*external, error) {
+	if client == nil {
+		return nil, fmt.Errorf("external auth requires an HTTP client")
+	}
+
+	return &external{
+		client:            client,
+		endpoint:          cfg.Endpoint,
+		setAuthHeaders:    cfg.SetAuthHeaders,
+		appendAuthHeaders: cfg.AppendAuthHeaders,
+	}, nil
+}
+
+func (e *external) Authorized(request *http.Request, response http.ResponseWriter) AuthDecision {
+	authRequest, err := http.NewRequestWithContext(request.Context(), http.MethodGet, e.endpoint, nil)
+	if err != nil {
+		return externalAuthError(response)
+	}
+
+	authRequest.Header = request.Header.Clone()
+	authRequest.Header.Del("Content-Length")
+	authRequest.Header.Del("Transfer-Encoding")
+	addExternalForwardHeaders(authRequest.Header, request)
+
+	authResponse, err := e.client.Do(authRequest)
+	if err != nil {
+		return externalAuthError(response)
+	}
+	defer authResponse.Body.Close()
+
+	if authResponse.StatusCode >= http.StatusOK && authResponse.StatusCode < http.StatusMultipleChoices {
+		for _, header := range e.setAuthHeaders {
+			request.Header.Del(header)
+			for _, value := range authResponse.Header.Values(header) {
+				request.Header.Add(header, value)
+			}
+		}
+
+		for _, header := range e.appendAuthHeaders {
+			for _, value := range authResponse.Header.Values(header) {
+				request.Header.Add(header, value)
+			}
+		}
+
+		_, _ = io.Copy(io.Discard, authResponse.Body)
+		return AuthDecision{Authorized: true}
+	}
+
+	copyExternalAuthResponseHeaders(response.Header(), authResponse.Header)
+	response.WriteHeader(authResponse.StatusCode)
+	_, _ = io.Copy(response, authResponse.Body)
+	return AuthDecision{Done: true}
+}
+
+func externalAuthError(response http.ResponseWriter) AuthDecision {
+	http.Error(response, "external authorization failed", http.StatusBadGateway)
+	return AuthDecision{Done: true}
+}
+
+func addExternalForwardHeaders(header http.Header, request *http.Request) {
+	header.Set("X-Forwarded-Method", request.Method)
+	requestURI := request.RequestURI
+	if requestURI == "" {
+		requestURI = request.URL.RequestURI()
+	}
+	header.Set("X-Forwarded-Uri", requestURI)
+
+	if header.Get("X-Forwarded-Host") == "" && request.Host != "" {
+		header.Set("X-Forwarded-Host", request.Host)
+	}
+
+	if header.Get("X-Forwarded-Proto") == "" {
+		proto := externalRequestScheme(request)
+		switch proto {
+		case "ws":
+			proto = "http"
+		case "wss":
+			proto = "https"
+		}
+		header.Set("X-Forwarded-Proto", proto)
+	}
+
+	if header.Get("X-Forwarded-Port") == "" {
+		header.Set("X-Forwarded-Port", externalRequestPort(request))
+	}
+
+	remoteIP, _, err := net.SplitHostPort(request.RemoteAddr)
+	if err != nil {
+		return
+	}
+
+	forwardedFor := remoteIP
+	if prior := header.Values("X-Forwarded-For"); len(prior) > 0 {
+		forwardedFor = strings.Join(prior, ", ") + ", " + remoteIP
+	}
+	header.Set("X-Forwarded-For", forwardedFor)
+
+	if header.Get("X-Real-Ip") == "" {
+		header.Set("X-Real-Ip", remoteIP)
+	}
+
+	if header.Get("Forwarded") == "" {
+		header.Set("Forwarded", "for="+remoteIP+"; proto="+externalRequestScheme(request))
+	}
+}
+
+func externalRequestScheme(request *http.Request) string {
+	if proto := request.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return proto
+	}
+
+	if forwarded := request.Header.Get("Forwarded"); forwarded != "" {
+		parts := strings.SplitAfterN(forwarded, "proto=", 2)
+		if len(parts) == 2 {
+			if n := strings.IndexRune(parts[1], ';'); n >= 0 {
+				return parts[1][:n]
+			}
+			return parts[1]
+		}
+	}
+
+	websocket := request.Header.Get("Upgrade") == "websocket"
+	switch {
+	case websocket && request.TLS != nil:
+		return "wss"
+	case websocket:
+		return "ws"
+	case request.TLS != nil:
+		return "https"
+	default:
+		return "http"
+	}
+}
+
+func externalRequestPort(request *http.Request) string {
+	if _, port, err := net.SplitHostPort(request.Host); err == nil && port != "" {
+		return port
+	}
+	if request.TLS != nil {
+		return "443"
+	}
+	return "80"
+}
+
+var externalHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Proxy-Connection":    true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+func copyExternalAuthResponseHeaders(dst, src http.Header) {
+	hopHeaders := make(map[string]bool, len(externalHopHeaders))
+	for header := range externalHopHeaders {
+		hopHeaders[header] = true
+	}
+	for _, value := range src.Values("Connection") {
+		for header := range strings.SplitSeq(value, ",") {
+			hopHeaders[http.CanonicalHeaderKey(strings.TrimSpace(header))] = true
+		}
+	}
+
+	for header, values := range src {
+		if hopHeaders[http.CanonicalHeaderKey(header)] {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(header, value)
+		}
+	}
+}

--- a/auth/external_test.go
+++ b/auth/external_test.go
@@ -1,0 +1,251 @@
+package auth
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fabiolb/fabio/config"
+)
+
+func TestExternal_Authorized(t *testing.T) {
+	var authRequest *http.Request
+	var authBody []byte
+	var authBodyErr error
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authRequest = r.Clone(r.Context())
+		authBody, authBodyErr = io.ReadAll(r.Body)
+
+		w.Header().Set("X-Auth-Request-User", "alice")
+		w.Header().Add("X-Auth-Request-Groups", "staff")
+		w.Header().Set("X-Unconfigured", "from-auth")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("accepted"))
+	}))
+	defer authServer.Close()
+
+	externalAuth, err := newExternalAuth(config.ExternalAuth{
+		Endpoint:          authServer.URL + "/oauth2/auth?fixed=1",
+		SetAuthHeaders:    []string{"X-Auth-Request-User", "X-Auth-Missing"},
+		AppendAuthHeaders: []string{"X-Auth-Request-Groups"},
+	}, noRedirectClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "http://app.example/private/resource?x=1", strings.NewReader("payload"))
+	request.Host = "app.example"
+	request.RemoteAddr = "192.0.2.10:4321"
+	request.RequestURI = "/private//resource?x=1"
+	request.Header.Set("X-Existing", "preserved")
+	request.Header.Set("X-Auth-Request-User", "spoofed")
+	request.Header.Set("X-Auth-Missing", "spoofed")
+	request.Header.Set("X-Auth-Request-Groups", "existing")
+	request.Header.Set("X-Unconfigured", "original")
+
+	decision := externalAuth.Authorized(request, httptest.NewRecorder())
+	if got, want := decision, (AuthDecision{Authorized: true}); got != want {
+		t.Fatalf("decision = %#v, want %#v", got, want)
+	}
+
+	if authRequest == nil {
+		t.Fatal("auth endpoint was not called")
+	}
+	if authBodyErr != nil {
+		t.Fatalf("read auth request body: %s", authBodyErr)
+	}
+	if len(authBody) != 0 {
+		t.Fatalf("auth request body = %q, want empty", authBody)
+	}
+	if got, want := authRequest.Method, http.MethodGet; got != want {
+		t.Errorf("auth method = %q, want %q", got, want)
+	}
+	if got, want := authRequest.URL.RequestURI(), "/oauth2/auth?fixed=1"; got != want {
+		t.Errorf("auth URI = %q, want %q", got, want)
+	}
+	if got, want := authRequest.Header.Get("X-Forwarded-Method"), http.MethodPost; got != want {
+		t.Errorf("X-Forwarded-Method = %q, want %q", got, want)
+	}
+	if got, want := authRequest.Header.Get("X-Forwarded-Uri"), "/private//resource?x=1"; got != want {
+		t.Errorf("X-Forwarded-Uri = %q, want %q", got, want)
+	}
+	if got, want := authRequest.Header.Get("X-Forwarded-Host"), "app.example"; got != want {
+		t.Errorf("X-Forwarded-Host = %q, want %q", got, want)
+	}
+	if got, want := authRequest.Header.Get("X-Forwarded-Proto"), "http"; got != want {
+		t.Errorf("X-Forwarded-Proto = %q, want %q", got, want)
+	}
+	if got, want := authRequest.Header.Get("X-Forwarded-For"), "192.0.2.10"; got != want {
+		t.Errorf("X-Forwarded-For = %q, want %q", got, want)
+	}
+	if got, want := authRequest.Header.Get("Forwarded"), "for=192.0.2.10; proto=http"; got != want {
+		t.Errorf("Forwarded = %q, want %q", got, want)
+	}
+	if got, want := authRequest.Header.Get("X-Existing"), "preserved"; got != want {
+		t.Errorf("cloned request header = %q, want %q", got, want)
+	}
+
+	if got, want := request.Header.Get("X-Auth-Request-User"), "alice"; got != want {
+		t.Errorf("set auth header = %q, want %q", got, want)
+	}
+	if got := request.Header.Get("X-Auth-Missing"); got != "" {
+		t.Errorf("missing set auth header = %q, want empty", got)
+	}
+	if got, want := request.Header.Values("X-Auth-Request-Groups"), []string{"existing", "staff"}; !stringSlicesEqual(got, want) {
+		t.Errorf("appended auth headers = %#v, want %#v", got, want)
+	}
+	if got, want := request.Header.Get("X-Unconfigured"), "original"; got != want {
+		t.Errorf("unconfigured auth response header changed request: got %q want %q", got, want)
+	}
+
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(body), "payload"; got != want {
+		t.Errorf("original request body = %q, want %q", got, want)
+	}
+}
+
+func TestExternal_DeniedResponse(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized},
+		{name: "forbidden", status: http.StatusForbidden},
+		{name: "redirect", status: http.StatusFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", "/oauth2/sign_in")
+				w.Header().Set("WWW-Authenticate", `Bearer realm="test"`)
+				w.Header().Add("Set-Cookie", "session=abc; Path=/")
+				w.Header().Set("Connection", "X-Hop")
+				w.Header().Set("X-Hop", "do-not-forward")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte("denied"))
+			}))
+			defer authServer.Close()
+
+			externalAuth, err := newExternalAuth(config.ExternalAuth{Endpoint: authServer.URL + "/oauth2/auth"}, noRedirectClient())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			recorder := httptest.NewRecorder()
+			decision := externalAuth.Authorized(httptest.NewRequest(http.MethodGet, "http://app.example/private", nil), recorder)
+			if got, want := decision, (AuthDecision{Done: true}); got != want {
+				t.Fatalf("decision = %#v, want %#v", got, want)
+			}
+			if got, want := recorder.Code, tt.status; got != want {
+				t.Errorf("status = %d, want %d", got, want)
+			}
+			if got, want := recorder.Body.String(), "denied"; got != want {
+				t.Errorf("body = %q, want %q", got, want)
+			}
+			if got, want := recorder.Header().Get("Location"), "/oauth2/sign_in"; got != want {
+				t.Errorf("Location = %q, want %q", got, want)
+			}
+			if got, want := recorder.Header().Get("WWW-Authenticate"), `Bearer realm="test"`; got != want {
+				t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+			}
+			if got, want := recorder.Header().Values("Set-Cookie"), []string{"session=abc; Path=/"}; !stringSlicesEqual(got, want) {
+				t.Errorf("Set-Cookie = %#v, want %#v", got, want)
+			}
+			if got := recorder.Header().Get("Connection"); got != "" {
+				t.Errorf("Connection header forwarded: %q", got)
+			}
+			if got := recorder.Header().Get("X-Hop"); got != "" {
+				t.Errorf("Connection-nominated header forwarded: %q", got)
+			}
+		})
+	}
+}
+
+func TestExternal_TransportFailureFailsClosed(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("auth unavailable")
+	})}
+	externalAuth, err := newExternalAuth(config.ExternalAuth{Endpoint: "http://auth.example/oauth2/auth"}, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	decision := externalAuth.Authorized(httptest.NewRequest(http.MethodGet, "http://app.example/private", nil), recorder)
+	if got, want := decision, (AuthDecision{Done: true}); got != want {
+		t.Fatalf("decision = %#v, want %#v", got, want)
+	}
+	if got, want := recorder.Code, http.StatusBadGateway; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestExternal_TimeoutFailsClosed(t *testing.T) {
+	client := &http.Client{
+		Timeout: 10 * time.Millisecond,
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		}),
+	}
+	externalAuth, err := newExternalAuth(config.ExternalAuth{Endpoint: "http://auth.example/oauth2/auth"}, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	decision := externalAuth.Authorized(httptest.NewRequest(http.MethodGet, "http://app.example/private", nil), recorder)
+	if got, want := decision, (AuthDecision{Done: true}); got != want {
+		t.Fatalf("decision = %#v, want %#v", got, want)
+	}
+	if got, want := recorder.Code, http.StatusBadGateway; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+}
+
+func TestLoadAuthSchemes_ExternalRequiresClient(t *testing.T) {
+	_, err := LoadAuthSchemes(map[string]config.AuthScheme{
+		"oauth": {
+			Name:     "oauth",
+			Type:     "external",
+			External: config.ExternalAuth{Endpoint: "http://auth.example/oauth2/auth"},
+		},
+	}, nil)
+	if err == nil || err.Error() != "external auth requires an HTTP client" {
+		t.Fatalf("error = %v, want external auth client error", err)
+	}
+}
+
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/config/config.go
+++ b/config/config.go
@@ -201,9 +201,10 @@ type Custom struct {
 }
 
 type AuthScheme struct {
-	Name  string
-	Type  string
-	Basic BasicAuth
+	Name     string
+	Type     string
+	Basic    BasicAuth
+	External ExternalAuth
 }
 
 type BasicAuth struct {
@@ -211,6 +212,12 @@ type BasicAuth struct {
 	Realm   string
 	File    string
 	Refresh time.Duration
+}
+
+type ExternalAuth struct {
+	Endpoint          string
+	SetAuthHeaders    []string
+	AppendAuthHeaders []string
 }
 
 type ConsulTlS struct {

--- a/config/load.go
+++ b/config/load.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -707,11 +708,37 @@ func parseAuthScheme(cfg map[string]string) (a AuthScheme, err error) {
 			a.Basic.Refresh = d
 		}
 
+	case "external":
+		a.External = ExternalAuth{
+			Endpoint:          cfg["endpoint"],
+			SetAuthHeaders:    parseAuthHeaders(cfg["set-auth-headers"]),
+			AppendAuthHeaders: parseAuthHeaders(cfg["append-auth-headers"]),
+		}
+
+		if a.External.Endpoint == "" {
+			return AuthScheme{}, fmt.Errorf("missing 'endpoint' in auth '%s'", a.Name)
+		}
+
+		u, err := url.Parse(a.External.Endpoint)
+		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return AuthScheme{}, fmt.Errorf("invalid 'endpoint' in auth '%s': must be an absolute http or https URL", a.Name)
+		}
+
 	default:
 		return AuthScheme{}, fmt.Errorf("unknown auth type '%s'", a.Type)
 	}
 
 	return
+}
+
+func parseAuthHeaders(s string) []string {
+	var headers []string
+	for h := range strings.SplitSeq(s, ",") {
+		if h = strings.TrimSpace(h); h != "" {
+			headers = append(headers, http.CanonicalHeaderKey(h))
+		}
+	}
+	return headers
 }
 
 func parseBGPPeers(cfgs string) ([]BGPPeer, error) {

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -284,6 +284,24 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			desc: "-proxy.auth with source external",
+			args: []string{"-proxy.auth", `name=oauth;type=external;endpoint=http://oauth2-proxy:4180/oauth2/auth;set-auth-headers="X-Auth-Request-User,X-Auth-Request-Email";append-auth-headers=X-Auth-Request-Groups`},
+			cfg: func(cfg *Config) *Config {
+				cfg.Proxy.AuthSchemes = map[string]AuthScheme{
+					"oauth": {
+						Name: "oauth",
+						Type: "external",
+						External: ExternalAuth{
+							Endpoint:          "http://oauth2-proxy:4180/oauth2/auth",
+							SetAuthHeaders:    []string{"X-Auth-Request-User", "X-Auth-Request-Email"},
+							AppendAuthHeaders: []string{"X-Auth-Request-Groups"},
+						},
+					},
+				}
+				return cfg
+			},
+		},
+		{
 			desc: "-proxy.addr with prometheus and https",
 			args: []string{"-proxy.addr", ":5555;cs=name;strictmatch=true;proto=prometheus", "-proxy.cs", "cs=name;type=path;cert=foo;clientca=bar;refresh=2s;hdr=a: b;caupgcn=furb"},
 			cfg: func(cfg *Config) *Config {
@@ -1131,6 +1149,24 @@ func TestLoad(t *testing.T) {
 			args: []string{"-proxy.auth", "name=foo;type=basic;realm=realm"},
 			cfg:  func(cfg *Config) *Config { return nil },
 			err:  errors.New("missing 'file' in auth 'foo'"),
+		},
+		{
+			desc: "-proxy.auth external with missing endpoint",
+			args: []string{"-proxy.auth", "name=oauth;type=external"},
+			cfg:  func(cfg *Config) *Config { return nil },
+			err:  errors.New("missing 'endpoint' in auth 'oauth'"),
+		},
+		{
+			desc: "-proxy.auth external with relative endpoint",
+			args: []string{"-proxy.auth", "name=oauth;type=external;endpoint=/oauth2/auth"},
+			cfg:  func(cfg *Config) *Config { return nil },
+			err:  errors.New("invalid 'endpoint' in auth 'oauth': must be an absolute http or https URL"),
+		},
+		{
+			desc: "-proxy.auth external with unsupported endpoint scheme",
+			args: []string{"-proxy.auth", "name=oauth;type=external;endpoint=ftp://auth.example/oauth2/auth"},
+			cfg:  func(cfg *Config) *Config { return nil },
+			err:  errors.New("invalid 'endpoint' in auth 'oauth': must be an absolute http or https URL"),
 		},
 		{
 			args: []string{"-glob.cache.size", "1000"},

--- a/docs/content/feature/authorization.md
+++ b/docs/content/feature/authorization.md
@@ -3,7 +3,7 @@ title: "Authorization"
 since: "1.5.11"
 ---
 
-fabio supports basic http authorization on a per-route basis.
+fabio supports basic and external HTTP authorization on a per-route basis.
 
 <!--more-->
 
@@ -29,6 +29,7 @@ When you configure the route, you must reference the unique name for the authori
 The following types of authorization schemes are available:
 
 * [`basic`](#basic): legacy store for a single TLS and a set of client auth certificates
+* [`external`](#external): delegate authorization to an HTTP endpoint
 
 At the end you also find a list of [examples](#examples).
 
@@ -43,6 +44,16 @@ Note: removing the htpasswd file will cause all requests to fail with HTTP statu
 
 Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpasswd)
 
+### External
+
+The external authorization scheme delegates each protected request to a fixed HTTP or HTTPS endpoint. Fabio sends a bodyless `GET` request to the configured `endpoint`, preserving the original request headers and adding `X-Forwarded-Method`, `X-Forwarded-Uri`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Port`, and client forwarding headers so the authorization service can evaluate the original request without consuming its body.
+
+Any 2xx response authorizes the original request. `set-auth-headers` is a comma-separated list of response headers that replace the corresponding headers on the upstream request. `append-auth-headers` is a comma-separated list whose values are appended instead. Header lists containing commas must be quoted in `proxy.auth` configuration.
+
+Non-2xx responses are returned to the client and the protected backend is not called. Redirects from the authorization endpoint are not followed by Fabio.
+
+    name=<name>;type=external;endpoint=<absolute-http-or-https-url>;set-auth-headers=<headers>;append-auth-headers=<headers>
+
 #### Examples
 
     # single basic auth scheme
@@ -54,3 +65,7 @@ Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpas
     # basic auth with multiple schemes
     proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s,
                  name=myotherauth;type=basic;file=p/other-creds.htpasswd;realm=myrealm
+
+    # oauth2-proxy authentication middleware
+    proxy.auth = name=oauth;type=external;endpoint=http://oauth2-proxy:4180/oauth2/auth;set-auth-headers="X-Auth-Request-User,X-Auth-Request-Email";append-auth-headers=X-Auth-Request-Groups
+    route add svc / http://127.0.0.1:8080 auth=oauth

--- a/docs/content/ref/proxy.auth.md
+++ b/docs/content/ref/proxy.auth.md
@@ -23,6 +23,16 @@ Note: removing the htpasswd file will cause all requests to fail with HTTP statu
 
 Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpasswd)
 
+#### External
+
+The external authorization scheme sends a bodyless `GET` request to a fixed absolute HTTP or HTTPS `endpoint` before forwarding the protected request. The authorization request includes the original headers plus forwarding metadata such as `X-Forwarded-Method` and `X-Forwarded-Uri`.
+
+All 2xx responses authorize the request. `set-auth-headers` selects response headers that replace the same headers on the upstream request, while `append-auth-headers` selects response headers whose values are appended. Quote comma-separated header lists in `proxy.auth` configuration.
+
+Non-2xx responses, including redirects, are returned directly to the client without calling the protected backend. Fabio does not follow authorization endpoint redirects.
+
+    name=<name>;type=external;endpoint=<absolute-http-or-https-url>;set-auth-headers=<headers>;append-auth-headers=<headers>
+
 #### Examples
 
     # single basic auth scheme
@@ -34,6 +44,9 @@ Supported htpasswd formats are detailed [here](https://github.com/tg123/go-htpas
     # basic auth with multiple schemes
     proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd;refresh=30s,
                  name=myotherauth;type=basic;file=p/other-creds.htpasswd;realm=myrealm
+
+    # oauth2-proxy authentication middleware
+    proxy.auth = name=oauth;type=external;endpoint=http://oauth2-proxy:4180/oauth2/auth;set-auth-headers="X-Auth-Request-User,X-Auth-Request-Email";append-auth-headers=X-Auth-Request-Groups
 
 The default is
 

--- a/fabio.properties
+++ b/fabio.properties
@@ -540,6 +540,22 @@
 #
 #   name=<name>;type=basic;file=p/creds.htpasswd;realm=foo
 #
+# External
+#
+# The external auth scheme delegates each protected HTTP request to a fixed
+# HTTP or HTTPS endpoint. Fabio sends a bodyless GET request to 'endpoint'
+# with the original request headers plus forwarding metadata including
+# X-Forwarded-Method and X-Forwarded-Uri.
+#
+# Any 2xx response authorizes the request. 'set-auth-headers' contains a
+# comma-separated list of auth response headers which replace the corresponding
+# headers on the upstream request. 'append-auth-headers' contains response
+# headers whose values are appended. Quote header lists containing commas.
+# Non-2xx responses are returned to the client without calling the backend,
+# and redirects from the auth endpoint are not followed.
+#
+#   name=<name>;type=external;endpoint=http://auth.example/auth;set-auth-headers="X-Auth-User,X-Auth-Email";append-auth-headers=X-Auth-Groups
+#
 # Examples
 #
 #   # single basic auth scheme
@@ -554,6 +570,10 @@
 #
 #   proxy.auth = name=mybasicauth;type=basic;file=p/creds.htpasswd
 #                name=myotherauth;type=basic;file=p/other-creds.htpasswd;realm=myrealm
+#
+#   # oauth2-proxy authentication middleware
+#
+#   proxy.auth = name=oauth;type=external;endpoint=http://oauth2-proxy:4180/oauth2/auth;set-auth-headers="X-Auth-Request-User,X-Auth-Request-Email";append-auth-headers=X-Auth-Request-Groups
 #
 #
 # proxy.grpcmaxrxmsgsize configures the grpc max receive message size in bytes.

--- a/main.go
+++ b/main.go
@@ -224,7 +224,14 @@ func newHTTPProxy(cfg *config.Config, statsHandler *proxy.HttpStatsHandler) *pro
 	log.Printf("[INFO] Using routing strategy %q", cfg.Proxy.Strategy)
 	log.Printf("[INFO] Using route matching %q", cfg.Proxy.Matcher)
 
-	authSchemes, err := auth.LoadAuthSchemes(cfg.Proxy.AuthSchemes)
+	authClient := &http.Client{
+		Transport: transport.NewTransport(nil),
+		Timeout:   cfg.Proxy.DialTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	authSchemes, err := auth.LoadAuthSchemes(cfg.Proxy.AuthSchemes, authClient)
 
 	if err != nil {
 		exit.Fatal("[FATAL] ", err)

--- a/proxy/http_integration_test.go
+++ b/proxy/http_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -20,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fabiolb/fabio/auth"
 	"github.com/fabiolb/fabio/config"
 	"github.com/fabiolb/fabio/logger"
 	"github.com/fabiolb/fabio/noroute"
@@ -190,6 +193,293 @@ func TestProxyChecksHeaderForAccessRules(t *testing.T) {
 
 	if got, want := resp.StatusCode, http.StatusForbidden; got != want {
 		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestProxyExternalAuth(t *testing.T) {
+	var backendCalls int
+	var backendBody string
+	var backendHeaders http.Header
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls++
+		backendHeaders = r.Header.Clone()
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read backend request body: %s", err)
+			return
+		}
+		backendBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	var authMethod, authURI, forwardedMethod, forwardedURI string
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authMethod = r.Method
+		authURI = r.URL.RequestURI()
+		forwardedMethod = r.Header.Get("X-Forwarded-Method")
+		forwardedURI = r.Header.Get("X-Forwarded-Uri")
+		w.Header().Set("X-Auth-Request-User", "alice")
+		w.Header().Add("X-Auth-Request-Groups", "staff")
+		w.Header().Set("X-Unconfigured", "auth-value")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer authServer.Close()
+
+	authClient := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	authSchemes, err := auth.LoadAuthSchemes(map[string]config.AuthScheme{
+		"oauth": {
+			Name: "oauth",
+			Type: "external",
+			External: config.ExternalAuth{
+				Endpoint:          authServer.URL + "/oauth2/auth?fixed=1",
+				SetAuthHeaders:    []string{"X-Auth-Request-User"},
+				AppendAuthHeaders: []string{"X-Auth-Request-Groups"},
+			},
+		},
+	}, authClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := httptest.NewServer(&HTTPProxy{
+		ProtectHeaders: testProtectHeaders,
+		Transport:      http.DefaultTransport,
+		AuthSchemes:    authSchemes,
+		Lookup: func(r *http.Request) *route.Target {
+			return &route.Target{URL: mustParse(backend.URL), AuthScheme: "oauth"}
+		},
+	})
+	defer proxy.Close()
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/private//resource?x=1", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Auth-Request-User", "spoofed")
+	req.Header.Set("X-Auth-Request-Groups", "existing")
+	req.Header.Set("X-Unconfigured", "original")
+	resp, body := mustDo(req)
+
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if len(body) != 0 {
+		t.Errorf("response body = %q, want empty", body)
+	}
+	if got, want := backendCalls, 1; got != want {
+		t.Fatalf("backend calls = %d, want %d", got, want)
+	}
+	if got, want := backendBody, "payload"; got != want {
+		t.Errorf("backend body = %q, want %q", got, want)
+	}
+	if got, want := backendHeaders.Get("X-Auth-Request-User"), "alice"; got != want {
+		t.Errorf("backend user header = %q, want %q", got, want)
+	}
+	if got, want := backendHeaders.Values("X-Auth-Request-Groups"), []string{"existing", "staff"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("backend groups header = %#v, want %#v", got, want)
+	}
+	if got, want := backendHeaders.Get("X-Unconfigured"), "original"; got != want {
+		t.Errorf("backend unconfigured header = %q, want %q", got, want)
+	}
+	if got, want := authMethod, http.MethodGet; got != want {
+		t.Errorf("auth method = %q, want %q", got, want)
+	}
+	if got, want := authURI, "/oauth2/auth?fixed=1"; got != want {
+		t.Errorf("auth URI = %q, want %q", got, want)
+	}
+	if got, want := forwardedMethod, http.MethodPost; got != want {
+		t.Errorf("X-Forwarded-Method = %q, want %q", got, want)
+	}
+	if got, want := forwardedURI, "/private//resource?x=1"; got != want {
+		t.Errorf("X-Forwarded-Uri = %q, want %q", got, want)
+	}
+}
+
+func TestProxyExternalAuthDenialStopsBackend(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusFound} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			backendCalls := 0
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				backendCalls++
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			authCalls := 0
+			authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authCalls++
+				w.Header().Set("Location", "/oauth2/sign_in")
+				w.Header().Set("WWW-Authenticate", `Bearer realm="test"`)
+				w.Header().Add("Set-Cookie", "session=abc; Path=/")
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte("denied"))
+			}))
+			defer authServer.Close()
+
+			authClient := &http.Client{
+				CheckRedirect: func(*http.Request, []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+			authSchemes, err := auth.LoadAuthSchemes(map[string]config.AuthScheme{
+				"oauth": {
+					Name:     "oauth",
+					Type:     "external",
+					External: config.ExternalAuth{Endpoint: authServer.URL + "/oauth2/auth"},
+				},
+			}, authClient)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			proxy := httptest.NewServer(&HTTPProxy{
+				ProtectHeaders: testProtectHeaders,
+				Transport:      http.DefaultTransport,
+				AuthSchemes:    authSchemes,
+				Lookup: func(r *http.Request) *route.Target {
+					return &route.Target{URL: mustParse(backend.URL), AuthScheme: "oauth"}
+				},
+			})
+			defer proxy.Close()
+
+			client := &http.Client{
+				CheckRedirect: func(*http.Request, []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+			resp, err := client.Get(proxy.URL + "/private")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := resp.StatusCode, status; got != want {
+				t.Errorf("status = %d, want %d", got, want)
+			}
+			if got, want := string(body), "denied"; got != want {
+				t.Errorf("body = %q, want %q", got, want)
+			}
+			if got, want := authCalls, 1; got != want {
+				t.Errorf("auth calls = %d, want %d", got, want)
+			}
+			if got := backendCalls; got != 0 {
+				t.Errorf("backend calls = %d, want 0", got)
+			}
+			if got, want := resp.Header.Get("Location"), "/oauth2/sign_in"; got != want {
+				t.Errorf("Location = %q, want %q", got, want)
+			}
+			if got, want := resp.Header.Get("WWW-Authenticate"), `Bearer realm="test"`; got != want {
+				t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+			}
+			if got, want := resp.Header.Values("Set-Cookie"), []string{"session=abc; Path=/"}; !reflect.DeepEqual(got, want) {
+				t.Errorf("Set-Cookie = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestProxyExternalAuthFailureStopsBackend(t *testing.T) {
+	backendCalls := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls++
+	}))
+	defer backend.Close()
+
+	authClient := &http.Client{Transport: proxyRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("auth unavailable")
+	})}
+	authSchemes, err := auth.LoadAuthSchemes(map[string]config.AuthScheme{
+		"oauth": {
+			Name:     "oauth",
+			Type:     "external",
+			External: config.ExternalAuth{Endpoint: "http://auth.example/oauth2/auth"},
+		},
+	}, authClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := httptest.NewServer(&HTTPProxy{
+		ProtectHeaders: testProtectHeaders,
+		Transport:      http.DefaultTransport,
+		AuthSchemes:    authSchemes,
+		Lookup: func(r *http.Request) *route.Target {
+			return &route.Target{URL: mustParse(backend.URL), AuthScheme: "oauth"}
+		},
+	})
+	defer proxy.Close()
+
+	resp, body := mustGet(proxy.URL + "/private")
+	if got, want := resp.StatusCode, http.StatusBadGateway; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got := backendCalls; got != 0 {
+		t.Errorf("backend calls = %d, want 0", got)
+	}
+	if got, want := string(body), "external authorization failed\n"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+type proxyRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f proxyRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestProxyBasicAuthStillReturnsChallenge(t *testing.T) {
+	backendCalls := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls++
+	}))
+	defer backend.Close()
+
+	filename := t.TempDir() + "/htpasswd"
+	if err := os.WriteFile(filename, []byte("foo:bar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	authSchemes, err := auth.LoadAuthSchemes(map[string]config.AuthScheme{
+		"basic": {
+			Name:  "basic",
+			Type:  "basic",
+			Basic: config.BasicAuth{File: filename, Realm: "test"},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := httptest.NewServer(&HTTPProxy{
+		ProtectHeaders: testProtectHeaders,
+		Transport:      http.DefaultTransport,
+		AuthSchemes:    authSchemes,
+		Lookup: func(r *http.Request) *route.Target {
+			return &route.Target{URL: mustParse(backend.URL), AuthScheme: "basic"}
+		},
+	})
+	defer proxy.Close()
+
+	resp, body := mustGet(proxy.URL + "/private")
+	if got, want := resp.StatusCode, http.StatusUnauthorized; got != want {
+		t.Errorf("status = %d, want %d", got, want)
+	}
+	if got, want := resp.Header.Get("WWW-Authenticate"), `Basic realm="test"`; got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+	if got, want := string(body), "authorization failed\n"; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	if got := backendCalls; got != 0 {
+		t.Errorf("backend calls = %d, want 0", got)
 	}
 }
 

--- a/proxy/http_proxy.go
+++ b/proxy/http_proxy.go
@@ -117,7 +117,11 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !t.Authorized(r, w, p.AuthSchemes) {
+	authDecision := t.Authorized(r, w, p.AuthSchemes)
+	if authDecision.Done {
+		return
+	}
+	if !authDecision.Authorized {
 		http.Error(w, "authorization failed", http.StatusUnauthorized)
 		return
 	}

--- a/route/auth.go
+++ b/route/auth.go
@@ -7,16 +7,16 @@ import (
 	"github.com/fabiolb/fabio/auth"
 )
 
-func (t *Target) Authorized(r *http.Request, w http.ResponseWriter, authSchemes map[string]auth.AuthScheme) bool {
+func (t *Target) Authorized(r *http.Request, w http.ResponseWriter, authSchemes map[string]auth.AuthScheme) auth.AuthDecision {
 	if t.AuthScheme == "" {
-		return true
+		return auth.AuthDecision{Authorized: true}
 	}
 
 	scheme := authSchemes[t.AuthScheme]
 
 	if scheme == nil {
 		log.Printf("[ERROR] unknown auth scheme '%s'\n", t.AuthScheme)
-		return false
+		return auth.AuthDecision{}
 	}
 
 	return scheme.Authorized(r, w)

--- a/route/auth_test.go
+++ b/route/auth_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 type testAuth struct {
-	ok bool
+	decision auth.AuthDecision
 }
 
-func (t *testAuth) Authorized(r *http.Request, w http.ResponseWriter) bool {
-	return t.ok
+func (t *testAuth) Authorized(r *http.Request, w http.ResponseWriter) auth.AuthDecision {
+	return t.decision
 }
 
 type responseWriter struct {
@@ -40,31 +40,39 @@ func TestTarget_Authorized(t *testing.T) {
 		name        string
 		authScheme  string
 		authSchemes map[string]auth.AuthScheme
-		out         bool
+		out         auth.AuthDecision
 	}{
 		{
 			name:       "matches correct auth scheme",
 			authScheme: "mybasic",
 			authSchemes: map[string]auth.AuthScheme{
-				"mybasic": &testAuth{ok: true},
+				"mybasic": &testAuth{decision: auth.AuthDecision{Authorized: true}},
 			},
-			out: true,
+			out: auth.AuthDecision{Authorized: true},
 		},
 		{
 			name:       "returns true when scheme is empty",
 			authScheme: "",
 			authSchemes: map[string]auth.AuthScheme{
-				"mybasic": &testAuth{ok: false},
+				"mybasic": &testAuth{},
 			},
-			out: true,
+			out: auth.AuthDecision{Authorized: true},
 		},
 		{
 			name:       "returns false when scheme is unknown",
 			authScheme: "foobar",
 			authSchemes: map[string]auth.AuthScheme{
-				"mybasic": &testAuth{ok: true},
+				"mybasic": &testAuth{decision: auth.AuthDecision{Authorized: true}},
 			},
-			out: false,
+			out: auth.AuthDecision{},
+		},
+		{
+			name:       "returns completed response decision from scheme",
+			authScheme: "external",
+			authSchemes: map[string]auth.AuthScheme{
+				"external": &testAuth{decision: auth.AuthDecision{Done: true}},
+			},
+			out: auth.AuthDecision{Done: true},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Add external HTTP authorization through the existing `proxy.auth` and route `auth=<name>` mechanism. A protected request can now delegate authorization to a fixed HTTP(S) endpoint; all 2xx responses allow the backend request, while non-2xx responses are returned directly without calling the backend.

## Changes

- Add `type=external` with `endpoint`, `set-auth-headers`, and `append-auth-headers` configuration.
- Send a bodyless GET to the configured endpoint using the original request context and forwarding metadata, without consuming the backend request body or following redirects.
- Apply only explicitly configured authorization response headers to successful upstream requests.
- Forward non-2xx status, body, and end-to-end response headers while filtering hop-by-hop headers.
- Fail closed on authorization endpoint errors and timeouts using a reusable HTTP client.
- Preserve existing basic auth and routes without authorization.
- Document external authorization and an oauth2-proxy `/oauth2/auth` example.

## Testing

Focused authorization and proxy regressions, the full Go test suite, and the repository build pass. The final diff also passes the whitespace check.

Fixes #1006