### PR TITLE
consider running govulncheck in CI

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,21 @@
+name: govulncheck
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '22 10 * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+      - run: |
+          go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
## Summary

Add a dedicated govulncheck workflow for pushes, pull requests, a daily 10:22 UTC schedule, and manual runs. It uses the Go version declared in `go.mod`, read-only repository permissions, non-persistent checkout credentials, and scans all Go packages without suppressing vulnerability findings.

## Testing

The workflow passed whitespace and dependency-scope checks. Running govulncheck with Go 1.27 reports GO-2026-4736 as reachable in GoBGP v4.8.0 and exits non-zero, confirming that vulnerability findings propagate as CI failures.

Fixes #1066