### PR TITLE
Update go proxyproto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mwitkow/grpc-proxy v0.0.0-20250813121105-2866842de9a5
 	github.com/osrg/gobgp/v4 v4.8.0
 	github.com/pascaldekloe/goe v0.1.1
-	github.com/pires/go-proxyproto v0.14.0
+	github.com/pires/go-proxyproto v0.15.0
 	github.com/pkg/profile v1.7.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/rogpeppe/fastuuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/pascaldekloe/goe v0.1.1 h1:Ah6WQ56rZONR3RW3qWa2NCZ6JAVvSpUcoLBaOmYFt9
 github.com/pascaldekloe/goe v0.1.1/go.mod h1:KSyfaxQOh0HZPjDP1FL/kFtbqYqrALJTaMafFUIccqU=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/pires/go-proxyproto v0.14.0 h1:2vIGIfVG8eVRsKF0xukEoeT5RWhDXxBU0uv6smLOKdI=
-github.com/pires/go-proxyproto v0.14.0/go.mod h1:OXsCrKwrK2tXS9YrI5tkHx5xaQlO8FH3lFW76orFh24=
+github.com/pires/go-proxyproto v0.15.0 h1:dTshmNbFm/D+0+sbrxUuddPOZ5Y0B7c5NhtsBkm6LqI=
+github.com/pires/go-proxyproto v0.15.0/go.mod h1:OXsCrKwrK2tXS9YrI5tkHx5xaQlO8FH3lFW76orFh24=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/proxy/inetaf_tcpproxy_integration_test.go
+++ b/proxy/inetaf_tcpproxy_integration_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -13,8 +14,10 @@ import (
 	"os"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/fabiolb/fabio/config"
+	"github.com/fabiolb/fabio/proxy/internal"
 	"github.com/fabiolb/fabio/proxy/tcp"
 	"github.com/fabiolb/fabio/proxy/tcp/tcptest"
 	"github.com/fabiolb/fabio/route"
@@ -213,6 +216,72 @@ func TestProxyHTTPSTCPSNIWithProxyProto(t *testing.T) {
 
 			testProxyProto(t, out)
 		})
+	}
+}
+
+// TestProxyHTTPSWithProxyProtoListenerNoHeader verifies that a plain HTTPS
+// connection succeeds when the listener has pxyproto enabled but the client
+// does not send a PROXY protocol header. go-proxyproto defaults to the USE
+// policy which falls through to normal connection handling when no header is
+// detected, so the request must complete successfully.
+func TestProxyHTTPSWithProxyProtoListenerNoHeader(t *testing.T) {
+	tmp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	proxyAddr := tmp.Addr().String()
+	tmp.Close()
+
+	go func() {
+		l := config.Listen{
+			Addr:               proxyAddr,
+			ProxyProto:         true,
+			ProxyHeaderTimeout: 250 * time.Millisecond,
+		}
+		if err := ListenAndServeHTTPSTCPSNI(l, okHandler, &tcp.SNIProxy{
+			Lookup: func(string) *route.Target { return nil },
+		}, tlsServerConfig(), func(_ context.Context, _ string) bool { return false }); err != nil {
+			t.Logf("ListenAndServeHTTPSTCPSNI: %v", err)
+		}
+	}()
+	defer Close()
+
+	rootCAs := x509.NewCertPool()
+	if ok := rootCAs.AppendCertsFromPEM(internal.LocalhostCert); !ok {
+		t.Fatal("could not parse cert")
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: rootCAs},
+			DialContext:     (&net.Dialer{}).DialContext,
+		},
+	}
+
+	// Retry until the listener is up, then send a plain HTTPS request with no
+	// PROXY protocol header.
+	var resp *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		resp, err = client.Get("https://" + proxyAddr)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("https GET failed: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		t.Errorf("status: got %d want %d", got, want)
+	}
+	if got, want := body, []byte("OK"); !bytes.Equal(got, want) {
+		t.Errorf("body: got %q want %q", got, want)
 	}
 }
 

--- a/proxy/listen.go
+++ b/proxy/listen.go
@@ -10,6 +10,12 @@ import (
 	proxyproto "github.com/pires/go-proxyproto"
 )
 
+func init() {
+	// go-proxyproto v0.15.0 DefaultPolicy changed to REQUIRE.
+	// retain old default to not break compatibility.
+	proxyproto.DefaultPolicy = proxyproto.USE
+}
+
 func ListenTCP(l config.Listen, cfg *tls.Config) (net.Listener, error) {
 	addr, err := net.ResolveTCPAddr("tcp", l.Addr)
 	if err != nil {


### PR DESCRIPTION
#1057 doesn't cover the breaking change to proxy protocol handling mentioned in the release notes for github.com/pires/go-proxyproto v0.15.0.