### PR TITLE
registry/custom: tests: shave off 3 seconds

### DIFF
--- a/registry/custom/custom_test.go
+++ b/registry/custom/custom_test.go
@@ -3,16 +3,15 @@ package custom
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fabiolb/fabio/config"
-	"github.com/fabiolb/fabio/route"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/fabiolb/fabio/config"
+	"github.com/fabiolb/fabio/route"
 )
 
 func TestCustomRoutes(t *testing.T) {
-
-	var resp string
 	cfg := config.Custom{
 		Host:               "localhost:8080",
 		Path:               "test",
@@ -36,7 +35,7 @@ func TestCustomRoutes(t *testing.T) {
 
 	go customRoutes(&cfg, ch)
 
-	resp = <-ch
+	resp := <-ch
 
 	if resp != "OK" {
 		fmt.Printf("Failed to get routes for custom backend - %s", resp)
@@ -45,7 +44,6 @@ func TestCustomRoutes(t *testing.T) {
 }
 
 func handleTest(w http.ResponseWriter, r *http.Request) {
-
 	var routes []route.RouteDef
 	var tags = []string{"tag1", "tag2"}
 	var opts = make(map[string]string)
@@ -88,5 +86,4 @@ func handleTest(w http.ResponseWriter, r *http.Request) {
 	rt, _ := json.Marshal(routes)
 
 	w.Write(rt)
-
 }

--- a/registry/custom/custom_test.go
+++ b/registry/custom/custom_test.go
@@ -3,6 +3,8 @@ package custom
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,26 +13,21 @@ import (
 )
 
 func TestCustomRoutes(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test", handleTest)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	host, _ := strings.CutPrefix(server.URL, "http://")
 	cfg := config.Custom{
-		Host:               "localhost:8080",
+		Host:               host,
 		Path:               "test",
 		Scheme:             "http",
 		CheckTLSSkipVerify: false,
 		PollInterval:       3 * time.Second,
 		Timeout:            3 * time.Second,
 	}
-
 	ch := make(chan string, 1)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/test", handleTest)
-	server := &http.Server{
-		Addr:    "localhost:8080",
-		Handler: mux,
-	}
-	go server.ListenAndServe()
-	time.Sleep(3 * time.Second)
-	defer server.Close()
 
 	go customRoutes(&cfg, ch)
 

--- a/registry/custom/custom_test.go
+++ b/registry/custom/custom_test.go
@@ -2,7 +2,6 @@ package custom
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -38,8 +37,7 @@ func TestCustomRoutes(t *testing.T) {
 	resp := <-ch
 
 	if resp != "OK" {
-		fmt.Printf("Failed to get routes for custom backend - %s", resp)
-		t.FailNow()
+		t.Fatalf("Failed to get routes for custom backend - %s", resp)
 	}
 }
 


### PR DESCRIPTION
Before

    go test ./registry/custom -count=1
    ok      github.com/fabiolb/fabio/registry/custom        3.379s

After

    go test ./registry/custom -count=1
    ok      github.com/fabiolb/fabio/registry/custom        0.375s

As a reminder, since `go test ./...` runs each package test in parallel, this does not mean that the runtime of the _whole_ suite is reduced by 3s.
